### PR TITLE
(FACT-1665) Add VirtualBox detector and DMI source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,9 @@ Gemfile.local
 Gemfile.lock
 
 # Generated files
-/exe/cpp-project-template.cc
-/lib/inc/cpp-project-template/cpp-project-template.hpp
 /lib/inc/*/export.h
 /lib/inc/*/version.h
-/lib/src/cpp-project-template.cc
-/lib/tests/cpp-project-template.cc
+/lib/tests/fixtures.hpp
 /lib/Doxyfile
 /lib/html/
 /lib/docs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,10 @@
-# Defines how cmake should behave, and the minimum version necessary to build.
 cmake_minimum_required(VERSION 3.2.2)
-
-# Project Setup - modify to match project naming
-## Source code for a simple command-line executable for a dynamic library will be generated from the project name.
-## The command-line and library names will be based off the project name.
 project(whereami VERSION 0.1.0)
 
 string(MAKE_C_IDENTIFIER ${PROJECT_NAME} PROJECT_C_NAME)
 string(TOUPPER ${PROJECT_C_NAME} PROJECT_NAME_UPPER)
 string(TOLOWER ${PROJECT_C_NAME} PROJECT_NAME_LOWER)
 
-# Common cmake setup
 if (NOT CMAKE_BUILD_TYPE)
     message(STATUS "Defaulting to a release build.")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
@@ -19,11 +13,15 @@ endif()
 enable_testing()
 
 # Leatherman setup
-SET(LEATHERMAN_COMPONENTS locale catch nowide logging)
+SET(LEATHERMAN_COMPONENTS locale catch nowide logging util file_util execution)
+
+if (WIN32)
+    list(APPEND LEATHERMAN_COMPONENTS windows)
+endif()
+
 find_package(Leatherman REQUIRED COMPONENTS ${LEATHERMAN_COMPONENTS})
 
-# Now that we have leatherman, we can pull in its options file, which
-# we need for finding all our other libraries.
+# Pull in leatherman options
 include(options)
 ## Pull in common cflags setting from leatherman. Don't override CMAKE_CXX_FLAGS at the project root to avoid impacting 3rd party code.
 include(cflags)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -17,7 +17,10 @@ leatherman_logging_namespace("puppetlabs.${PROJECT_NAME}")
 # Setup compiling the library.
 include_directories(inc ${Boost_INCLUDE_DIRS} ${LEATHERMAN_INCLUDE_DIRS})
 
-set(PROJECT_SOURCES "src/${PROJECT_NAME}.cc")
+set(PROJECT_SOURCES
+    "src/${PROJECT_NAME}.cc"
+    "src/detectors/virtualbox_detector.cc"
+    "src/sources/dmi_source.cc")
 
 ## An object target is generated that can be used by both the library and test executable targets.
 ## Without the intermediate target, unexported symbols can't be tested.

--- a/lib/inc/internal/detectors/virtualbox_detector.hpp
+++ b/lib/inc/internal/detectors/virtualbox_detector.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <internal/sources/dmi_source.hpp>
+
+namespace whereami { namespace detectors {
+
+    /**
+     * VirtualBox detector function
+     * @param dmi_source An instance of a DMI data source
+     * @return Whether this machine is a VirtualBox guest
+     */
+    bool virtualbox(const sources::dmi_base& dmi_source);
+
+}}  // namespace whereami::detectors

--- a/lib/inc/internal/sources/dmi_source.hpp
+++ b/lib/inc/internal/sources/dmi_source.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace whereami { namespace sources {
+
+    /**
+     * Stores information collected via DMI
+     */
+    struct dmi_data
+    {
+        /**
+         * The name of the BIOS vendor
+         * via /sys/class/dmi/id/bios_vendor or dmidecode section 0 vendor
+         */
+        std::string bios_vendor;
+        /**
+         * The board manufacturer
+         * via /sys/class/dmi/id/board_vendor or dmidecode section 2 manufacturer
+         */
+        std::string board_manufacturer;
+        /**
+         * The board product name
+         * via /sys/class/dmi/id/board_name or dmidecode section 2 product name
+         */
+        std::string board_product_name;
+        /**
+         * The system manufacturer (via /sys/class/dmi/id/sys_vendor)
+         * via /sys/class/dmi/id/sys_vendor or dmidecode section 1 manufacturer
+         */
+        std::string manufacturer;
+        /**
+         * The product name
+         * via /sys/class/dmi/id/product_name or dmidecode section 1 product name
+         */
+        std::string product_name;
+    };
+
+    /**
+     * Base DMI data source
+     */
+    class dmi_base
+    {
+    public:
+        dmi_base() {}
+        virtual ~dmi_base() {}
+        /**
+         * Retrieve the BIOS vendor
+         * @return The BIOS vendor's name
+         */
+        std::string bios_vendor() const;
+        /**
+         * Retrieve the board manufacturer
+         * @return The board manufacturer's name
+         */
+        std::string board_manufacturer() const;
+        /**
+         * Retrieve the board product name
+         * @return The board product name
+         */
+        std::string board_product_name() const;
+        /**
+         * Retrieve the system manufacturer
+         * @return The system manufacturer
+         */
+        std::string manufacturer() const;
+        /**
+         * Retrieve the product name
+         * @return The product name
+         */
+        std::string product_name() const;
+    protected:
+        /**
+         * Collected data for this machine based on DMI information
+         */
+        std::unique_ptr<dmi_data> data_;
+    };
+
+    /**
+     * Default DMI data source
+     */
+    class dmi : public dmi_base
+    {
+     public:
+        dmi();
+        virtual ~dmi() {}
+     protected:
+        /**
+         * /sys path to user-accessible DMI files on *nix systems
+         */
+        constexpr static char const* SYS_PATH = "/sys/class/dmi/id/";
+        /**
+         * Attempt to collect virtualization data using DMI
+         */
+        virtual void collect_data();
+        /**
+         * Attempt to collect data from files in /sys/class/dmi/id/
+         */
+        virtual void collect_data_from_sys();
+        /**
+         * Attempt to collect data from dmidecode executable (requires root)
+         */
+        virtual void collect_data_from_dmidecode();
+        /**
+         * Construct a full pathname for files in /sys/class/dmi/id/
+         * @param filename The name of the file expected to exist in /sys/class/dmi/id/, e.g. "bios_vendor"
+         * @return The full path to the file
+         */
+        virtual std::string sys_path(std::string const& filename = "") const;
+        /**
+         * Read a single DMI file
+         * @param path The path to the file
+         * @return The contents of the file
+         */
+        std::string read_file(std::string const& path);
+        /**
+         * Examine a line of dmidecode output for useful information
+         * @param line The contents of the line
+         * @param dmi_type Initial dmi_type value, e.g. -1
+         */
+        void parse_dmidecode_line(std::string& line, int& dmi_type);
+    };
+
+}}  // namespace whereami::sources

--- a/lib/inc/internal/vm.hpp
+++ b/lib/inc/internal/vm.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+/**
+ * Virtual machine name constants
+ */
+namespace whereami { namespace vm {
+
+    /**
+     * The name for VMWare virtual machine.
+     */
+    constexpr static char const* vmware{"vmware"};
+
+    /**
+     * The name for VirtualBox virtual machine.
+     */
+    constexpr static char const* virtualbox{"virtualbox"};
+
+    /**
+     * The name for Parallels virtual machine.
+     */
+    constexpr static char const* parallels{"parallels"};
+
+    /**
+     * The name for VMware Server virtual machine.
+     */
+    constexpr static char const* vmware_server{"vmware_server"};
+
+    /**
+     * The name for VMware Workstation virtual machine.
+     */
+    constexpr static char const* vmware_workstation{"vmware_workstation"};
+
+    /**
+     * The name for Docker virtual machine.
+     */
+    constexpr static char const* docker{"docker"};
+
+    /**
+     * The name for LXC virtual machine.
+     */
+    constexpr static char const* lxc{"lxc"};
+
+    /**
+     * The name for systemd-nspawn
+     */
+    constexpr static char const* systemd_nspawn{"systemd_nspawn"};
+
+    /**
+     * The name for Google Compute Engine virtual machine.
+     */
+    constexpr static char const* gce{"gce"};
+
+    /**
+     * The name for OpenStack-hosted virtual machine, when OpenStack defines the machine type.
+     */
+    constexpr static char const* openstack{"openstack"};
+
+    /**
+     * The name for Xen privileged domain virtual machine.
+     */
+    constexpr static char const* xen_privileged{"xen0"};
+
+    /**
+     * The name for Xen unprivileged domain virtual machine.
+     */
+    constexpr static char const* xen_unprivileged{"xenu"};
+
+    /**
+     * The name for Xen Hardware virtual machine.
+     */
+    constexpr static char const* xen_hardware{"xenhvm"};
+
+    /**
+     * The name for Xen virtual machine (on Windows)
+     */
+    constexpr static char const* xen{"xen"};
+
+    /**
+     * The name for IBM System Z virtual machine.
+     */
+    constexpr static char const* zlinux{"zlinux"};
+
+    /**
+     * The name for Linux-VServer host virtual machine.
+     */
+    constexpr static char const* vserver_host{"vserver_host"};
+
+    /**
+     * The name for Linux-VServer virtual machine.
+     */
+    constexpr static char const* vserver{"vserver"};
+
+    /**
+     * The name for OpenVZ Hardware Node virtual machine.
+     */
+    constexpr static char const* openvz_hn{"openvzhn"};
+
+    /**
+     * The name for OpenVZ Virtual Environment virtual machine.
+     */
+    constexpr static char const* openvz_ve{"openvzve"};
+
+    /**
+     * The name for KVM (QEMU) virtual machine.
+     */
+    constexpr static char const* kvm{"kvm"};
+
+    /**
+     * The name for Bochs virtual machine.
+     */
+    constexpr static char const* bochs{"bochs"};
+
+    /**
+     * The name for Microsoft Hyper-V virtual machine.
+     */
+    constexpr static char const* hyperv{"hyperv"};
+
+    /**
+     * The name for Red Hat Enterprise Virtualization virtual machine.
+     */
+    constexpr static char const* redhat_ev{"rhev"};
+
+    /**
+     * The name for oVirt virtual machine.
+     */
+    constexpr static char const* ovirt{"ovirt"};
+
+    /**
+     * The name for Solaris zones
+     */
+    constexpr static char const* zone{"zone"};
+
+    /**
+     * The name for Solaris ldom
+     */
+    constexpr static char const* ldom{"ldom"};
+
+}}  // namespace whereami::vm

--- a/lib/inc/whereami/whereami.hpp
+++ b/lib/inc/whereami/whereami.hpp
@@ -1,10 +1,7 @@
-/**
- * @file
- * Declares a utility for retrieving the library version.
- */
 #pragma once
 
 #include <string>
+#include <vector>
 #include "export.h"
 
 namespace whereami {
@@ -14,5 +11,11 @@ namespace whereami {
      * @return A version string with \<major>.\<minor>.\<patch>
      */
     std::string LIBWHEREAMI_EXPORT version();
+
+    /**
+     * Try to detect whether this machine is a guest on any hypervisors
+     * @return A vector of detected hypervisor names
+     */
+    std::vector<std::string> LIBWHEREAMI_EXPORT hypervisors();
 
 }  // namespace whereami

--- a/lib/src/detectors/virtualbox_detector.cc
+++ b/lib/src/detectors/virtualbox_detector.cc
@@ -1,0 +1,21 @@
+#include <internal/detectors/virtualbox_detector.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <leatherman/execution/execution.hpp>
+#include <leatherman/util/regex.hpp>
+
+using namespace std;
+using namespace whereami;
+using namespace leatherman::execution;
+using namespace leatherman::util;
+
+namespace whereami { namespace detectors {
+
+    bool virtualbox(const sources::dmi_base& dmi_source) {
+        static const boost::regex re_virtualbox{"[Vv]irtual[Bb]ox"};
+
+        return re_search(
+            dmi_source.product_name(),
+            re_virtualbox);
+    }
+
+}}  // namespace whereami::detectors

--- a/lib/src/sources/dmi_source.cc
+++ b/lib/src/sources/dmi_source.cc
@@ -1,0 +1,206 @@
+#include <internal/sources/dmi_source.hpp>
+#include <leatherman/util/regex.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <leatherman/file_util/file.hpp>
+#include <leatherman/execution/execution.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+
+using namespace std;
+using namespace boost::filesystem;
+namespace bs = boost::system;
+namespace lth_file = leatherman::file_util;
+using namespace leatherman::util;
+
+namespace whereami { namespace sources {
+
+    std::string dmi_base::bios_vendor() const
+    {
+        return data_ ? data_->bios_vendor : "";
+    }
+
+    std::string dmi_base::board_manufacturer() const
+    {
+        return data_ ? data_->board_manufacturer : "";
+    }
+
+    std::string dmi_base::board_product_name() const
+    {
+        return data_ ? data_->board_product_name : "";
+    }
+
+    std::string dmi_base::product_name() const
+    {
+        return data_ ? data_->product_name : "";
+    }
+
+    std::string dmi_base::manufacturer() const
+    {
+        return data_ ? data_->manufacturer : "";
+    }
+
+    dmi::dmi()
+    {
+        collect_data();
+    }
+
+    void dmi::collect_data()
+    {
+        collect_data_from_sys();
+        if (data_.get() == nullptr) {
+            collect_data_from_dmidecode();
+        }
+    }
+
+    string dmi::sys_path(string const& filename) const
+    {
+        return SYS_PATH + filename;
+    }
+
+    void dmi::collect_data_from_sys()
+    {
+        // Check that /sys/class/dmi exists
+        bs::error_code ec;
+        if (is_directory(sys_path(), ec)) {
+            data_.reset(new dmi_data);
+            data_->bios_vendor = read_file(sys_path("bios_vendor"));
+            data_->board_manufacturer = read_file(sys_path("board_vendor"));
+            data_->board_product_name = read_file(sys_path("board_name"));
+            data_->manufacturer = read_file(sys_path("sys_vendor"));
+            data_->product_name = read_file(sys_path("product_name"));
+        } else {
+            LOG_DEBUG(sys_path() + " cannot be accessed.");
+        }
+    }
+
+    void dmi::collect_data_from_dmidecode()
+    {
+        LOG_DEBUG("Using dmidecode to query DMI information.");
+
+        string dmidecode = leatherman::execution::which("dmidecode");
+
+        if (dmidecode.empty()) {
+            LOG_DEBUG("dmidecode executable not found");
+        } else {
+            int dmi_type {-1};
+            leatherman::execution::each_line(dmidecode, [&](string& line) {
+                parse_dmidecode_line(line, dmi_type);
+                return true;
+            });
+        }
+    }
+
+    // Read a single file in the DMI directory
+    string dmi::read_file(string const& path)
+    {
+        bs::error_code ec;
+        if (!is_regular_file(path, ec)) {
+            LOG_DEBUG("{1}: {2}.", path, ec.message());
+            return {};
+        }
+
+        string value;
+        if (!lth_file::read(path, value)) {
+            LOG_DEBUG("{1}: file could not be read.", path);
+            return {};
+        }
+
+        boost::trim(value);
+
+        // Replace any non-printable ASCII characters with '.'
+        // This mimics the behavior of dmidecode
+        for (auto& c : value) {
+            if (c < 32 || c == 127) {
+                c = '.';
+            }
+        }
+        return value;
+    }
+
+    void dmi::parse_dmidecode_line(string& line, int& dmi_type)
+    {
+        static const boost::regex dmi_section_pattern{"^Handle 0x.{4}, DMI type (\\d{1,3})"};
+
+        // Stores the relevant sections; this is in order based on DMI type ID
+        // Ensure there's a trailing semicolon on each entry and keep in sync with the switch statement below
+        static const vector<vector<string>> sections{
+            {   // BIOS (0)
+                "vendor:",
+            },
+            {   // System (1)
+                "manufacturer:",
+                "product name:",
+            },
+            {   // Base Board (2)
+                "manufacturer:",
+                "product name:",
+            }
+        };
+
+        // Check for a section header
+        if (re_search(line, dmi_section_pattern, &dmi_type)) {
+            return;
+        }
+
+        // Check that we're in a relevant section
+        if (dmi_type < 0 || static_cast<size_t>(dmi_type) >= sections.size()) {
+            return;
+        }
+
+        // Trim leading whitespace
+        boost::trim_left(line);
+
+        // Find a matching header
+        auto const& headers = sections[dmi_type];
+        auto it = find_if(headers.begin(), headers.end(), [&](string const& header) {
+            return boost::istarts_with(line, header);
+        });
+        if (it == headers.end()) {
+            return;
+        }
+
+        // Get the value and trim it
+        string value{line.substr(it->size())};
+        boost::trim(value);
+
+        // Calculate the index into the header vector
+        auto index = it - headers.begin();
+
+        // Assign to the appropriate member
+        string* member{nullptr};
+        switch (dmi_type) {
+            case 0: {  // BIOS information
+                if (index == 0) {
+                    member = &data_->bios_vendor;
+                }
+                break;
+            }
+
+            case 1: {  // System information
+                if (index == 0) {
+                    member = &data_->manufacturer;
+                } else if (index == 1 || index == 2) {
+                    member = &data_->product_name;
+                }
+                break;
+            }
+
+            case 2: {  // Base board information
+                if (index == 0) {
+                    member = &data_->board_manufacturer;
+                } else if (index == 1 || index == 2) {
+                    member = &data_->board_product_name;
+                }
+                break;
+            }
+
+            default:
+                break;
+        }
+
+        if (member) {
+            *member = std::move(value);
+        }
+    }
+
+}};  // namespace whereami::sources

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -1,11 +1,14 @@
-#include <whereami/version.h>
 #include <whereami/whereami.hpp>
-
+#include <whereami/version.h>
+#include <internal/vm.hpp>
+#include <internal/sources/dmi_source.hpp>
+#include <internal/detectors/virtualbox_detector.hpp>
 #include <leatherman/logging/logging.hpp>
 
-namespace whereami {
+using namespace std;
+using namespace whereami;
 
-    using namespace std;
+namespace whereami {
 
     string version()
     {
@@ -13,4 +16,17 @@ namespace whereami {
         return WHEREAMI_VERSION_WITH_COMMIT;
     }
 
-}  // whereami
+    vector<string> hypervisors()
+    {
+        vector<string> result;
+        sources::dmi dmi_source;
+
+        auto virtualbox_result = detectors::virtualbox(dmi_source);
+
+        if (virtualbox_result) {
+            result.emplace_back(vm::virtualbox);
+        }
+
+        return result;
+    }
+}  // namespace whereami

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -1,7 +1,12 @@
 # Setup compiling the test executable. C++ compile flags are inherited from the parent directory.
 include_directories(${LEATHERMAN_CATCH_INCLUDE})
 
-set(TEST_CASES ${PROJECT_NAME}.cc)
+set(TEST_CASES
+    "${PROJECT_NAME}.cc"
+    "detectors/virtualbox_detector.cc"
+    "fixtures.cc"
+    "fixtures/dmi_fixtures.cc"
+    "sources/dmi_source.cc")
 
 add_executable(lib${PROJECT_NAME}_test $<TARGET_OBJECTS:libprojectsrc> ${TEST_CASES} main.cc)
 target_link_libraries(lib${PROJECT_NAME}_test
@@ -10,3 +15,6 @@ target_link_libraries(lib${PROJECT_NAME}_test
 )
 
 add_test(NAME "unit_tests" COMMAND lib${PROJECT_NAME}_test)
+
+# Generate a file containing the path to the fixtures
+configure_file("fixtures.hpp.in" "${CMAKE_CURRENT_LIST_DIR}/fixtures.hpp")

--- a/lib/tests/detectors/virtualbox_detector.cc
+++ b/lib/tests/detectors/virtualbox_detector.cc
@@ -1,0 +1,30 @@
+#include <catch.hpp>
+#include <internal/sources/dmi_source.hpp>
+#include <internal/detectors/virtualbox_detector.hpp>
+#include "../fixtures/dmi_fixtures.hpp"
+
+using namespace std;
+using namespace whereami::detectors;
+using namespace whereami::sources;
+using namespace whereami::testing::dmi;
+
+SCENARIO("Using the VirtualBox detector") {
+    WHEN("running in a VirtualBox VM") {
+        dmi_fixture_values dmi_virtualbox({
+            "VirtualBox",
+            "VirtualBox",
+            "Oracle Corporation",
+            "innotek GmbH",
+            "VirtualBox" });
+        THEN("it should return true") {
+            REQUIRE(virtualbox(dmi_virtualbox));
+        }
+    }
+
+    WHEN("running elsewhere") {
+        dmi_fixture_empty dmi_empty;
+        THEN("it should return false") {
+            REQUIRE_FALSE(virtualbox(dmi_empty));
+        }
+    }
+}

--- a/lib/tests/fixtures.cc
+++ b/lib/tests/fixtures.cc
@@ -1,0 +1,32 @@
+#include "fixtures.hpp"
+#include <boost/filesystem.hpp>
+#include <boost/nowide/fstream.hpp>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#include <boost/thread/thread.hpp>
+#include <boost/chrono/duration.hpp>
+#pragma GCC diagnostic pop
+
+using namespace std;
+using namespace boost::filesystem;
+
+namespace whereami { namespace testing {
+
+    bool load_fixture(string const& name, string& data)
+    {
+        string path {string {LIBWHEREAMI_TESTS_DIRECTORY} + "/fixtures/" + name};
+        boost::nowide::ifstream in(path.c_str(), ios_base::in | ios_base::binary);
+        if (!in) {
+            return false;
+        }
+        ostringstream buffer;
+        buffer << in.rdbuf();
+        data = buffer.str();
+        return true;
+    }
+
+}}  // namespace whereami::testing

--- a/lib/tests/fixtures.hpp.in
+++ b/lib/tests/fixtures.hpp.in
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <internal/sources/dmi_source.hpp>
+#include <string>
+#include <functional>
+
+#define LIBWHEREAMI_TESTS_DIRECTORY "@CMAKE_CURRENT_LIST_DIR@"
+
+namespace whereami { namespace testing {
+
+    static const auto fixture_root = std::string{std::string{LIBWHEREAMI_TESTS_DIRECTORY} + "/fixtures"};
+
+    bool load_fixture(std::string const& name, std::string& data);
+
+}}  // namespace whereami::testing

--- a/lib/tests/fixtures/dmi_fixtures.cc
+++ b/lib/tests/fixtures/dmi_fixtures.cc
@@ -1,0 +1,42 @@
+#include "./dmi_fixtures.hpp"
+
+using namespace whereami::testing;
+using namespace whereami::sources;
+using namespace std;
+
+namespace whereami { namespace testing { namespace dmi {
+
+    dmi_fixture_sys::dmi_fixture_sys(const char* base_directory)
+        : base_directory_(base_directory)
+    {
+        collect_data_from_sys();
+    }
+
+    std::string dmi_fixture_sys::sys_path(std::string const& filename) const
+    {
+        return fixture_root + base_directory_ + filename;
+    }
+
+    dmi_fixture_dmidecode::dmi_fixture_dmidecode(const char* dmidecode_fixture_path)
+        : dmidecode_fixture_path_(dmidecode_fixture_path)
+    {
+        collect_data_from_dmidecode();
+    }
+    void dmi_fixture_dmidecode::collect_data_from_dmidecode()
+    {
+        int dmi_type = -1;
+        std::string dmidecode_output;
+        if (!load_fixture(dmidecode_fixture_path_, dmidecode_output)) return;
+        data_.reset(new dmi_data);
+        leatherman::util::each_line(dmidecode_output, [&](string& line) {
+            parse_dmidecode_line(line, dmi_type);
+            return true;
+        });
+    }
+
+    dmi_fixture_values::dmi_fixture_values(sources::dmi_data&& data)
+    {
+        data_.reset(new dmi_data(move(data)));
+    }
+
+}}}  // namespace whereami::testing::dmi

--- a/lib/tests/fixtures/dmi_fixtures.hpp
+++ b/lib/tests/fixtures/dmi_fixtures.hpp
@@ -1,0 +1,75 @@
+#include "../fixtures.hpp"
+#include <internal/sources/dmi_source.hpp>
+#include <leatherman/util/strings.hpp>
+#include <string>
+#include <sstream>
+
+namespace whereami { namespace testing { namespace dmi {
+
+    /**
+     * DMI data source returning no usable information
+     */
+    using dmi_fixture_empty = whereami::sources::dmi_base;
+
+    /**
+     * DMI data source relying on a fixture directory for /sys/class/dmi/id/
+     */
+    class dmi_fixture_sys : public sources::dmi {
+    public:
+        /**
+         * Constructor setting the fixture base directory
+         * @param base_directory within lib/tests/fixtures/
+         */
+        dmi_fixture_sys(const char* base_directory);
+        ~dmi_fixture_sys() {}
+    protected:
+        /**
+         * Base fixture directory containing dmi files for the current test
+         */
+        std::string base_directory_;
+        /**
+         * Override sys_path to construct file paths based on a fixture directory instead of /sys/class/dmi/id/
+         * @param filename The name of a file to read
+         * @return The contents of the file
+         */
+        std::string sys_path(std::string const&) const override;
+    };
+
+    /**
+     * DMI data source relying on dmidecode output
+     */
+    class dmi_fixture_dmidecode : public sources::dmi {
+    public:
+        /**
+         * Constructor specifying the location of the dmidecode output fixture (within lib/tests/fixtures/)
+         * @param dmidecode_fixture_path Path to a fixture containing dmidecode output
+         */
+        dmi_fixture_dmidecode(const char* dmidecode_fixture_path = "");
+        ~dmi_fixture_dmidecode() {}
+    protected:
+        /**
+         * The fixture file path
+         */
+        std::string dmidecode_fixture_path_;
+        /**
+         * /sys/class/dmi/id/ data collection (noop)
+         * @return
+         */
+        void collect_data_from_sys() override {}
+        /**
+         * Load data from the fixture file (instead of the dmidecode executable output)
+         * @return
+         */
+        void collect_data_from_dmidecode() override;
+    };
+
+    /**
+     * DMI data source relying on explicitly specified values
+     */
+    class dmi_fixture_values : public sources::dmi_base {
+    public:
+        dmi_fixture_values(sources::dmi_data&& data);
+        ~dmi_fixture_values() {}
+    };
+
+}}}  // namespace whereami::testing::dmi

--- a/lib/tests/fixtures/dmidecode/none.txt
+++ b/lib/tests/fixtures/dmidecode/none.txt
@@ -1,0 +1,2 @@
+# dmidecode 2.12
+# No SMBIOS nor DMI entry point found, sorry.

--- a/lib/tests/fixtures/dmidecode/virtualbox.txt
+++ b/lib/tests/fixtures/dmidecode/virtualbox.txt
@@ -1,0 +1,81 @@
+Getting SMBIOS data from sysfs.
+SMBIOS 2.5 present.
+10 structures occupying 450 bytes.
+Table at 0x000E1000.
+
+Handle 0x0000, DMI type 0, 20 bytes
+BIOS Information
+	Vendor: innotek GmbH
+	Version: VirtualBox
+	Release Date: 12/01/2006
+	Address: 0xE0000
+	Runtime Size: 128 kB
+	ROM Size: 128 kB
+	Characteristics:
+		ISA is supported
+		PCI is supported
+		Boot from CD is supported
+		Selectable boot is supported
+		8042 keyboard services are supported (int 9h)
+		CGA/mono video services are supported (int 10h)
+		ACPI is supported
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+	Manufacturer: innotek GmbH
+	Product Name: VirtualBox
+	Version: 1.2
+	Serial Number: 0
+	UUID: AA0AD9A8-8B3D-45E1-968F-A7796EBA264F
+	Wake-up Type: Power Switch
+	SKU Number: Not Specified
+	Family: Virtual Machine
+
+Handle 0x0008, DMI type 2, 15 bytes
+Base Board Information
+	Manufacturer: Oracle Corporation
+	Product Name: VirtualBox
+	Version: 1.2
+	Serial Number: 0
+	Asset Tag: Not Specified
+	Features:
+		Board is a hosting board
+	Location In Chassis: Not Specified
+	Chassis Handle: 0x0003
+	Type: Motherboard
+	Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 13 bytes
+Chassis Information
+	Manufacturer: Oracle Corporation
+	Type: Other
+	Lock: Not Present
+	Version: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Boot-up State: Safe
+	Power Supply State: Safe
+	Thermal State: Safe
+	Security Status: None
+
+Handle 0x0007, DMI type 126, 42 bytes
+Inactive
+
+Handle 0x0005, DMI type 126, 15 bytes
+Inactive
+
+Handle 0x0006, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x0002, DMI type 11, 7 bytes
+OEM Strings
+	String 1: vboxVer_5.1.22
+	String 2: vboxRev_115126
+
+Handle 0x0008, DMI type 128, 8 bytes
+OEM-specific Type
+	Header and Data:
+		80 08 08 00 E5 1A 29 00
+
+Handle 0xFEFF, DMI type 127, 4 bytes
+End Of Table

--- a/lib/tests/fixtures/sys/dmi/virtualbox/bios_vendor
+++ b/lib/tests/fixtures/sys/dmi/virtualbox/bios_vendor
@@ -1,0 +1,1 @@
+innotek GmbH

--- a/lib/tests/fixtures/sys/dmi/virtualbox/board_name
+++ b/lib/tests/fixtures/sys/dmi/virtualbox/board_name
@@ -1,0 +1,1 @@
+VirtualBox

--- a/lib/tests/fixtures/sys/dmi/virtualbox/board_vendor
+++ b/lib/tests/fixtures/sys/dmi/virtualbox/board_vendor
@@ -1,0 +1,1 @@
+Oracle Corporation

--- a/lib/tests/fixtures/sys/dmi/virtualbox/product_name
+++ b/lib/tests/fixtures/sys/dmi/virtualbox/product_name
@@ -1,0 +1,1 @@
+VirtualBox

--- a/lib/tests/fixtures/sys/dmi/virtualbox/sys_vendor
+++ b/lib/tests/fixtures/sys/dmi/virtualbox/sys_vendor
@@ -1,0 +1,1 @@
+innotek GmbH

--- a/lib/tests/sources/dmi_source.cc
+++ b/lib/tests/sources/dmi_source.cc
@@ -1,0 +1,58 @@
+#include <catch.hpp>
+#include <internal/sources/dmi_source.hpp>
+#include <leatherman/file_util/file.hpp>
+#include <leatherman/util/strings.hpp>
+#include <boost/filesystem.hpp>
+#include "../fixtures/dmi_fixtures.hpp"
+
+using namespace std;
+using namespace leatherman::util;
+using namespace whereami::sources;
+using namespace whereami::testing::dmi;
+
+
+SCENARIO("Using the DMI data source") {
+    WHEN("DMI is not available") {
+        dmi_fixture_empty dmi_source;
+        THEN("nothing should be found") {
+            REQUIRE(dmi_source.bios_vendor().empty());
+            REQUIRE(dmi_source.board_manufacturer().empty());
+            REQUIRE(dmi_source.board_product_name().empty());
+            REQUIRE(dmi_source.manufacturer().empty());
+            REQUIRE(dmi_source.product_name().empty());
+        }
+    }
+
+    WHEN("DMI data is available in /sys/class/dmi/id/") {
+        dmi_fixture_sys dmi_source("/sys/dmi/virtualbox/");
+        THEN("all fields should be populated via /sys/") {
+            REQUIRE(dmi_source.bios_vendor() == "innotek GmbH");
+            REQUIRE(dmi_source.board_manufacturer() == "Oracle Corporation");
+            REQUIRE(dmi_source.board_product_name() == "VirtualBox");
+            REQUIRE(dmi_source.manufacturer() == "innotek GmbH");
+            REQUIRE(dmi_source.product_name() == "VirtualBox");
+        }
+    }
+
+    WHEN("Using dmidecode when data is not available") {
+        dmi_fixture_dmidecode dmi_source{"dmidecode/none.txt"};
+        THEN("nothing should be found") {
+            REQUIRE(dmi_source.bios_vendor().empty());
+            REQUIRE(dmi_source.board_manufacturer().empty());
+            REQUIRE(dmi_source.board_product_name().empty());
+            REQUIRE(dmi_source.manufacturer().empty());
+            REQUIRE(dmi_source.product_name().empty());
+        }
+    }
+
+    WHEN("Using dmidecode when data is available") {
+        dmi_fixture_dmidecode dmi_source{"dmidecode/virtualbox.txt"};
+        THEN("all fields should be populated via dmidecode") {
+            REQUIRE(dmi_source.bios_vendor() == "innotek GmbH");
+            REQUIRE(dmi_source.board_manufacturer() == "Oracle Corporation");
+            REQUIRE(dmi_source.board_product_name() == "VirtualBox");
+            REQUIRE(dmi_source.manufacturer() == "innotek GmbH");
+            REQUIRE(dmi_source.product_name() == "VirtualBox");
+        }
+    }
+}


### PR DESCRIPTION
Exploratory examples of two central entities planned for this library:

- Data sources gather data from some set of files, executables, etc.  This
  commit includes a source for DMI information which first checks some files in
  /sys/class/dmi/id/ (accessible by all users) and, failing that, attempts to
  use `dmidecode`, which requires root.
- Detectors query sources and report whether a certain hypervisor is in use.
  This commit includes a VirtualBox detector that uses the dmi source. Output
  is currently yes/no, but in the future this will likely change to include
  additional metadata.