### PR TITLE
(FACT-1716) Add metadata to detector output

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -19,6 +19,8 @@ include_directories(inc ${Boost_INCLUDE_DIRS} ${LEATHERMAN_INCLUDE_DIRS})
 
 set(PROJECT_SOURCES
     "src/${PROJECT_NAME}.cc"
+    "src/detectors/metadata.cc"
+    "src/detectors/result.cc"
     "src/detectors/virtualbox_detector.cc"
     "src/sources/cpuid_source.cc"
     "src/sources/dmi_source.cc")

--- a/lib/inc/internal/detectors/metadata.hpp
+++ b/lib/inc/internal/detectors/metadata.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <unordered_map>
+#include <boost/variant.hpp>
+
+namespace whereami { namespace detectors {
+
+    /**
+     * Metadata values can be string or boolean
+     */
+    using metadata_value = boost::variant<std::string, bool>;
+
+    /**
+     * Metadata container
+     */
+    class metadata
+    {
+    public:
+        /**
+         * Set a key with a string value using a string
+         * @param key The key
+         * @param value The value
+         */
+        void set(std::string const& key, std::string const& value);
+
+        /**
+         * Set a key with a string value using a string literal
+         * @param key The key
+         * @param value The value
+         */
+        void set(std::string const& key, const char *value);
+
+        /**
+         * Set a key with a boolean value
+         * @param key The key
+         * @param value The value
+         */
+        void set(std::string const& key, bool value);
+
+        /**
+         * Retrieve a metadata value by key
+         * @tparam T The expected type of the value
+         * @param key The key
+         * @return
+         */
+        template<typename T>
+        T get(std::string const& key) const throw(boost::bad_get)
+        {
+            auto it = data_.find(key);
+            if (it == data_.end()) {
+                return {};
+            }
+            return boost::get<T>((*it).second);
+        }
+
+    protected:
+        /**
+         * Metadata key/value map
+         */
+        std::unordered_map <std::string, metadata_value> data_;
+    };
+
+}}  // namespace whereami::detectors

--- a/lib/inc/internal/detectors/result.hpp
+++ b/lib/inc/internal/detectors/result.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <internal/detectors/metadata.hpp>
+
+namespace whereami { namespace detectors {
+
+    /**
+     * Represents the result of a hypervisor detector
+     */
+    class result
+    {
+    public:
+        /**
+         * Constructs a result given a hypervisor name
+         * @param name The name of the hypervisor this result represents
+         */
+        result(std::string const& name): name_(name) {}
+
+        /**
+         * Retrieves the name of the hypervisor
+         * @return Returns name of the hypervisor
+         */
+        std::string name() const;
+
+        /**
+         * Reports whether the hypervisor was detected
+         * @return Returns true if the hypervisor was detected
+         */
+        bool valid() const;
+
+        /**
+         * Marks the result as having successfully detected the hypervisor
+         */
+        void validate();
+
+        /**
+         * Sets a metadata key and value
+         * @tparam T The type of the value
+         * @param key The key
+         * @param value The value
+         */
+        template<typename T>
+        void set(std::string const& key, T&& value)
+        {
+            metadata_.set(key, std::forward<T>(value));
+        }
+
+        /**
+         * Retrieves a metadata value by key
+         * @tparam T The expected type of the value
+         * @param key The key
+         * @return Returns the value
+         */
+        template<typename T>
+        T get(std::string const& key) const throw(boost::bad_get)
+        {
+            return metadata_.get<T>(key);
+        }
+
+    protected:
+        /**
+         * The name of the hypervisor this result respresents
+         */
+        std::string name_;
+        /**
+         * Whether this hypervisor has been detected
+         */
+        bool valid_ = false;
+        /**
+         * Metadata about the hypervisor
+         */
+        metadata metadata_;
+    };
+
+}};  // namespace whereami::detectors

--- a/lib/inc/internal/detectors/virtualbox_detector.hpp
+++ b/lib/inc/internal/detectors/virtualbox_detector.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <internal/detectors/result.hpp>
 #include <internal/sources/dmi_source.hpp>
 #include <internal/sources/cpuid_source.hpp>
 
@@ -11,7 +12,7 @@ namespace whereami { namespace detectors {
      * @param dmi_source An instance of a DMI data source
      * @return Whether this machine is a VirtualBox guest
      */
-    bool virtualbox(const sources::cpuid_base& cpuid_source,
-                    const sources::dmi_base& dmi_source);
+    result virtualbox(const sources::cpuid_base& cpuid_source,
+                      const sources::dmi_base& dmi_source);
 
 }}  // namespace whereami::detectors

--- a/lib/inc/internal/sources/dmi_source.hpp
+++ b/lib/inc/internal/sources/dmi_source.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace whereami { namespace sources {
 
@@ -35,6 +36,11 @@ namespace whereami { namespace sources {
          * via /sys/class/dmi/id/product_name or dmidecode section 1 product name
          */
         std::string product_name;
+        /**
+         * OEM strings
+         * Only available via dmidecode section 11 (requires root)
+         */
+        std::vector<std::string> oem_strings;
     };
 
     /**
@@ -70,6 +76,11 @@ namespace whereami { namespace sources {
          * @return The product name
          */
         std::string product_name() const;
+        /**
+         * Retrieve any OEM strings
+         * @return A vector of OEM strings
+         */
+        std::vector<std::string> oem_strings() const;
     protected:
         /**
          * Collected data for this machine based on DMI information

--- a/lib/inc/whereami/whereami.hpp
+++ b/lib/inc/whereami/whereami.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string>
+#include <internal/detectors/result.hpp>
 #include <vector>
 #include "export.h"
 
@@ -16,6 +16,6 @@ namespace whereami {
      * Try to detect whether this machine is a guest on any hypervisors
      * @return A vector of detected hypervisor names
      */
-    std::vector<std::string> LIBWHEREAMI_EXPORT hypervisors();
+    std::vector<detectors::result> LIBWHEREAMI_EXPORT hypervisors();
 
 }  // namespace whereami

--- a/lib/src/detectors/metadata.cc
+++ b/lib/src/detectors/metadata.cc
@@ -1,0 +1,22 @@
+#include <internal/detectors/metadata.hpp>
+
+using namespace std;
+
+namespace whereami { namespace detectors {
+
+    void metadata::set(string const& key, bool value)
+    {
+        data_.emplace(key, value);
+    }
+
+    void metadata::set(string const& key, const char* value)
+    {
+        data_.emplace(key, string {value});
+    }
+
+    void metadata::set(string const& key, string const& value)
+    {
+        data_.emplace(key, value);
+    }
+
+}}  // namespace whereami::detectors

--- a/lib/src/detectors/result.cc
+++ b/lib/src/detectors/result.cc
@@ -1,0 +1,21 @@
+#include <internal/detectors/result.hpp>
+
+using namespace std;
+
+namespace whereami { namespace detectors {
+
+    bool result::valid() const
+    {
+        return valid_;
+    }
+
+    void result::validate()
+    {
+        valid_ = true;
+    }
+
+    std::string result::name() const
+    {
+        return name_;
+    }
+}}  // namespace whereami::detectors

--- a/lib/src/detectors/virtualbox_detector.cc
+++ b/lib/src/detectors/virtualbox_detector.cc
@@ -1,5 +1,7 @@
 #include <internal/detectors/virtualbox_detector.hpp>
 #include <leatherman/util/regex.hpp>
+#include <internal/vm.hpp>
+#include <boost/algorithm/string.hpp>
 
 using namespace std;
 using namespace whereami;
@@ -7,12 +9,29 @@ using namespace leatherman::util;
 
 namespace whereami { namespace detectors {
 
-    bool virtualbox(const sources::cpuid_base& cpuid_source,
-                    const sources::dmi_base& dmi_source) {
-        static const boost::regex re_virtualbox{"[Vv]irtual[Bb]ox"};
+    result virtualbox(const sources::cpuid_base& cpuid_source,
+                      const sources::dmi_base& dmi_source) {
+        result res {vm::virtualbox};
 
-        return cpuid_source.vendor() == "VBoxVBoxVBox" ||
-            re_search(dmi_source.product_name(), re_virtualbox);
+        if (cpuid_source.vendor() == "VBoxVBoxVBox" ||
+            dmi_source.product_name() == "VirtualBox") {
+            res.validate();
+
+            // Look for VirtualBox version and revision in DMI OEM strings
+            auto oem_strings = dmi_source.oem_strings();
+
+            for (auto const& oem_string : dmi_source.oem_strings()) {
+                if (boost::istarts_with(oem_string, "vboxVer_")) {
+                    auto version = oem_string.substr(8, string::npos);
+                    res.set("version", version);
+                } else if (boost::istarts_with(oem_string, "vboxRev_")) {
+                    auto revision = oem_string.substr(8, string::npos);
+                    res.set("revision", revision);
+                }
+            }
+        }
+
+        return res;
     }
 
 }}  // namespace whereami::detectors

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -8,6 +8,7 @@
 
 using namespace std;
 using namespace whereami;
+using namespace whereami::detectors;
 
 namespace whereami {
 
@@ -17,18 +18,18 @@ namespace whereami {
         return WHEREAMI_VERSION_WITH_COMMIT;
     }
 
-    vector<string> hypervisors()
+    vector<result> hypervisors()
     {
-        vector<string> result;
+        vector<result> results;
         sources::dmi dmi_source;
         sources::cpuid cpuid_source;
 
         auto virtualbox_result = detectors::virtualbox(cpuid_source, dmi_source);
 
-        if (virtualbox_result) {
-            result.emplace_back(vm::virtualbox);
+        if (virtualbox_result.valid()) {
+            results.emplace_back(virtualbox_result);
         }
 
-        return result;
+        return results;
     }
 }  // namespace whereami

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -3,6 +3,8 @@ include_directories(${LEATHERMAN_CATCH_INCLUDE})
 
 set(TEST_CASES
     "${PROJECT_NAME}.cc"
+    "detectors/metadata.cc"
+    "detectors/result.cc"
     "detectors/virtualbox_detector.cc"
     "fixtures.cc"
     "fixtures/cpuid_fixtures.cc"

--- a/lib/tests/detectors/metadata.cc
+++ b/lib/tests/detectors/metadata.cc
@@ -1,0 +1,42 @@
+#include <catch.hpp>
+#include <internal/detectors/metadata.hpp>
+
+using namespace std;
+using namespace whereami;
+using namespace whereami::detectors;
+
+SCENARIO("Using a metadata object") {
+    WHEN("a string literal metadata value is added") {
+        metadata data;
+        data.set("foo", "bar");
+        THEN("it is retrievable as a string") {
+            REQUIRE(data.get<string>("foo") == "bar");
+        }
+        THEN("it is not retrievable as another data type") {
+            REQUIRE_THROWS_AS(data.get<bool>("foo"), boost::bad_get);
+        }
+    }
+
+    WHEN("a string metadata value is added") {
+        metadata data;
+        string bar {"bar"};
+        data.set("foo", bar);
+        THEN("it is retrievable as a string") {
+            REQUIRE(data.get<string>("foo") == "bar");
+        }
+        THEN("it is not retrievable as another data type") {
+            REQUIRE_THROWS_AS(data.get<bool>("foo"), boost::bad_get);
+        }
+    }
+
+    WHEN("a boolean metadata value is added") {
+        metadata data;
+        data.set("foo", true);
+        THEN("it is retrievable as a boolean") {
+            REQUIRE(data.get<bool>("foo"));
+        }
+        THEN("it is not retrievable as another data type") {
+            REQUIRE_THROWS_AS(data.get<string>("foo"), boost::bad_get);
+        }
+    }
+}

--- a/lib/tests/detectors/result.cc
+++ b/lib/tests/detectors/result.cc
@@ -1,0 +1,35 @@
+#include <catch.hpp>
+#include <internal/detectors/result.hpp>
+#include <internal/vm.hpp>
+
+using namespace std;
+using namespace whereami;
+using namespace whereami::detectors;
+
+SCENARIO("Using a detector result") {
+    WHEN("it is newly created") {
+        result res {vm::kvm};
+        THEN("it is not valid") {
+            REQUIRE_FALSE(res.valid());
+        }
+        THEN("the name can be retrieved") {
+            REQUIRE(res.name() == vm::kvm);
+        }
+        AND_WHEN("it is validated") {
+            res.validate();
+            THEN("it is valid") {
+                REQUIRE(res.valid());
+            }
+        }
+    }
+
+    WHEN("working with metadata") {
+        result res {vm::kvm};
+        THEN("values can be set") {
+            REQUIRE_NOTHROW(res.set("foo", "bar"));
+            AND_THEN("they can be retrieved") {
+                REQUIRE(res.get<string>("foo") == "bar");
+            }
+        }
+    }
+}

--- a/lib/tests/detectors/virtualbox_detector.cc
+++ b/lib/tests/detectors/virtualbox_detector.cc
@@ -21,7 +21,7 @@ SCENARIO("Using the VirtualBox detector") {
             "VirtualBox",
             "Oracle Corporation",
             "innotek GmbH",
-            "VirtualBox", });
+            "VirtualBox", {}});
         THEN("it should return true") {
             REQUIRE(virtualbox(cpuid_source, dmi_source));
         }
@@ -48,7 +48,7 @@ SCENARIO("Using the VirtualBox detector") {
             "Other",
             "Other",
             "Other",
-            "Other", });
+            "Other", {}});
         THEN("it should return false") {
             REQUIRE_FALSE(virtualbox(cpuid_source, dmi_source));
         }

--- a/lib/tests/fixtures.hpp.in
+++ b/lib/tests/fixtures.hpp.in
@@ -8,7 +8,7 @@
 
 namespace whereami { namespace testing {
 
-    static const auto fixture_root = std::string{std::string{LIBWHEREAMI_TESTS_DIRECTORY} + "/fixtures"};
+    static const auto fixture_root = std::string{std::string{LIBWHEREAMI_TESTS_DIRECTORY} + "/fixtures/"};
 
     bool load_fixture(std::string const& name, std::string& data);
 

--- a/lib/tests/fixtures/dmi_fixtures.cc
+++ b/lib/tests/fixtures/dmi_fixtures.cc
@@ -6,28 +6,23 @@ using namespace std;
 
 namespace whereami { namespace testing { namespace dmi {
 
-    dmi_fixture_sys::dmi_fixture_sys(const char* base_directory)
-        : base_directory_(base_directory)
+    dmi_fixture::dmi_fixture(std::string dmidecode_path, std::string sys_path)
+        : dmidecode_fixture_path_(dmidecode_path), sys_fixture_path_(sys_path)
     {
-        collect_data_from_sys();
+        data_.reset(nullptr);
+        collect_data();
     }
 
-    std::string dmi_fixture_sys::sys_path(std::string const& filename) const
+    std::string dmi_fixture::sys_path(std::string const& filename = "") const
     {
-        return fixture_root + base_directory_ + filename;
+        return fixture_root + sys_fixture_path_ + filename;
     }
 
-    dmi_fixture_dmidecode::dmi_fixture_dmidecode(const char* dmidecode_fixture_path)
-        : dmidecode_fixture_path_(dmidecode_fixture_path)
-    {
-        collect_data_from_dmidecode();
-    }
-    void dmi_fixture_dmidecode::collect_data_from_dmidecode()
+    void dmi_fixture::collect_data_from_dmidecode()
     {
         int dmi_type = -1;
         std::string dmidecode_output;
         if (!load_fixture(dmidecode_fixture_path_, dmidecode_output)) return;
-        data_.reset(new dmi_data);
         leatherman::util::each_line(dmidecode_output, [&](string& line) {
             parse_dmidecode_line(line, dmi_type);
             return true;

--- a/lib/tests/fixtures/dmi_fixtures.hpp
+++ b/lib/tests/fixtures/dmi_fixtures.hpp
@@ -6,61 +6,44 @@
 
 namespace whereami { namespace testing { namespace dmi {
 
-    /**
-     * DMI data source returning no usable information
-     */
-    using dmi_fixture_empty = whereami::sources::dmi_base;
+    using dmi_fixture_empty = sources::dmi_base;
 
     /**
-     * DMI data source relying on a fixture directory for /sys/class/dmi/id/
+     * Common fixture paths within the fixture base path
      */
-    class dmi_fixture_sys : public sources::dmi {
-    public:
-        /**
-         * Constructor setting the fixture base directory
-         * @param base_directory within lib/tests/fixtures/
-         */
-        dmi_fixture_sys(const char* base_directory);
-        ~dmi_fixture_sys() {}
-    protected:
-        /**
-         * Base fixture directory containing dmi files for the current test
-         */
-        std::string base_directory_;
-        /**
-         * Override sys_path to construct file paths based on a fixture directory instead of /sys/class/dmi/id/
-         * @param filename The name of a file to read
-         * @return The contents of the file
-         */
-        std::string sys_path(std::string const&) const override;
-    };
+    namespace dmi_fixtures {
+        static const std::string SYS_NONE = "<none>";
+        static const std::string SYS_VIRTUALBOX = "sys/dmi/virtualbox/";
+        static const std::string DMIDECODE_NONE = "dmidecode/none.txt";
+        static const std::string DMIDECODE_VIRTUALBOX = "dmidecode/virtualbox.txt";
+    }
 
     /**
-     * DMI data source relying on dmidecode output
+     * DMI data source relying on fixtures for dmidecode output and /sys/class/dmi/id/ files
      */
-    class dmi_fixture_dmidecode : public sources::dmi {
+    class dmi_fixture : public sources::dmi {
     public:
-        /**
-         * Constructor specifying the location of the dmidecode output fixture (within lib/tests/fixtures/)
-         * @param dmidecode_fixture_path Path to a fixture containing dmidecode output
-         */
-        dmi_fixture_dmidecode(const char* dmidecode_fixture_path = "");
-        ~dmi_fixture_dmidecode() {}
+        dmi_fixture(std::string dmidecode_path = dmi_fixtures::DMIDECODE_NONE,
+                    std::string sys_path       = dmi_fixtures::SYS_NONE);
     protected:
         /**
-         * The fixture file path
-         */
-        std::string dmidecode_fixture_path_;
-        /**
-         * /sys/class/dmi/id/ data collection (noop)
+         * Read /sys/ data from a fixture base path (instead of from /sys/)
          * @return
          */
-        void collect_data_from_sys() override {}
+        std::string sys_path(std::string const&) const override;
         /**
-         * Load data from the fixture file (instead of the dmidecode executable output)
+         * Read dmidecode data from a fixture file (instead of the dmidecode executable output)
          * @return
          */
         void collect_data_from_dmidecode() override;
+        /**
+         * The dmidecode fixture file path
+         */
+        std::string dmidecode_fixture_path_;
+        /**
+         * The /sys/ fixture directory path
+         */
+        std::string sys_fixture_path_;
     };
 
     /**


### PR DESCRIPTION
**First commit** (preparation for second commit)
 
Adds a vector of OEM strings to the collected data from the DMI source. This information is not available in the /sys/class/dmi/id/ directory, so it can only be collected with root privileges via dmidecode (or the DMI table).

Not all vendors store useful information in the OEM strings, but VirtualBox, for example, reports the hypervisor version and revision there.

Also refactors DMI tests so that a single fixture class can use fixtures for files in `/sys/class/dmi/id/` and `dmidecode` output simultaneously.

**Second commit**

Introduces two new entities:
- A metadata object wrapping a map of keys (strings) to values (strings or bools, currently)
- A result object to replace the boolean return type of detectors. A result reports whether a hypervisor was detected and contains a metadata object with any other hypervisor information gleaned by the detector.

Changes the return type of the main `hypervisors()` function from a vector of hypervisor name strings to a vector of result objects. Updates the VirtualBox detector to include version and revision metadata.