### PR TITLE
(FACT-1717) Add VMware detector

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,6 +22,7 @@ set(PROJECT_SOURCES
     "src/detectors/metadata.cc"
     "src/detectors/result.cc"
     "src/detectors/virtualbox_detector.cc"
+    "src/detectors/vmware_detector.cc"
     "src/sources/cpuid_source.cc"
     "src/sources/dmi_source.cc")
 

--- a/lib/inc/internal/detectors/vmware_detector.hpp
+++ b/lib/inc/internal/detectors/vmware_detector.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <internal/detectors/result.hpp>
+#include <internal/sources/cpuid_source.hpp>
+#include <internal/sources/dmi_source.hpp>
+#include <string>
+
+namespace whereami { namespace detectors {
+
+    /**
+     * VMware detector function
+     * @param cpuid_source An instance of a CPUID data source
+     * @param dmi_source An instance of a DMI data source
+     * @return The VMware detection result
+     */
+    result vmware(const sources::cpuid_base& cpuid_source,
+                  const sources::dmi_base& dmi_source);
+
+}}  // namespace whereami::detectors

--- a/lib/inc/internal/sources/dmi_source.hpp
+++ b/lib/inc/internal/sources/dmi_source.hpp
@@ -12,6 +12,11 @@ namespace whereami { namespace sources {
     struct dmi_data
     {
         /**
+         * The BIOS address
+         * Only available via dmidecode section 0 (requires root)
+         */
+        std::string bios_address;
+        /**
          * The name of the BIOS vendor
          * via /sys/class/dmi/id/bios_vendor or dmidecode section 0 vendor
          */
@@ -51,6 +56,11 @@ namespace whereami { namespace sources {
     public:
         dmi_base() {}
         virtual ~dmi_base() {}
+        /**
+         * Retrieve the BIOS address
+         * @return The BIOS address
+         */
+        std::string bios_address() const;
         /**
          * Retrieve the BIOS vendor
          * @return The BIOS vendor's name

--- a/lib/src/detectors/vmware_detector.cc
+++ b/lib/src/detectors/vmware_detector.cc
@@ -1,0 +1,62 @@
+#include <internal/detectors/vmware_detector.hpp>
+#include <internal/vm.hpp>
+#include <leatherman/execution/execution.hpp>
+#include <leatherman/util/regex.hpp>
+
+using namespace whereami;
+using namespace leatherman::util;
+using namespace std;
+
+/**
+ * Retrieve the VMware version based on a DMI BIOS address result, if possible
+ * @param address The value of the BIOS address from DMI
+ * @return The VMware version
+ */
+static string vmware_bios_address_to_version(int address)
+{
+    const std::unordered_map<int, std::string> version_map {
+        { 0xe8480, "ESXi 2.5" },
+        { 0xe7c70, "ESXi 3.0" },
+        { 0xe66c0, "ESXi 3.5" },
+        { 0xe7910, "ESXi 3.5" },
+        { 0xea550, "ESXi 4.0" },
+        { 0xea6c0, "ESXi 4.0" },
+        { 0xea2e0, "ESXi 4.1" },
+        { 0xe72c0, "ESXi 5.0" },
+        { 0xea0c0, "ESXi 5.1" },
+        { 0xea050, "ESXi 5.5" },
+        { 0xe99e0, "ESXi 6.0" },
+        { 0xea580, "ESXi 6.5" },
+        { 0xea5e0, "Fusion 8.5" },
+    };
+
+    auto it = version_map.find(address);
+
+    if (it != version_map.end()) {
+        return it->second;
+    }
+    return {};
+}
+
+namespace whereami { namespace detectors {
+
+    result vmware(const sources::cpuid_base& cpuid_source,
+                  const sources::dmi_base& dmi_source)
+    {
+        result res {vm::vmware};
+
+        if (dmi_source.manufacturer() == "VMware, Inc." ||
+            cpuid_source.vendor() == "VMwareVMware") {
+            res.validate();
+
+            auto bios_address = dmi_source.bios_address();
+            if (!bios_address.empty()) {
+                auto value = stoi(bios_address, nullptr, 16);
+                res.set("version", vmware_bios_address_to_version(value));
+            }
+        }
+
+        return res;
+    }
+
+}}  // namespace whereami::detectors

--- a/lib/src/sources/dmi_source.cc
+++ b/lib/src/sources/dmi_source.cc
@@ -15,6 +15,11 @@ using namespace leatherman::util;
 
 namespace whereami { namespace sources {
 
+    std::string dmi_base::bios_address() const
+    {
+        return data_ ? data_->bios_address : "";
+    }
+
     std::string dmi_base::bios_vendor() const
     {
         return data_ ? data_->bios_vendor : "";
@@ -138,6 +143,7 @@ namespace whereami { namespace sources {
         static const unordered_map<int, vector<string>> sections {
             { 0, {  // BIOS
                 "vendor:",
+                "address:",
             }},
             { 1, {  // System
                 "manufacturer:",
@@ -193,6 +199,9 @@ namespace whereami { namespace sources {
             case 0: {  // BIOS information
                 if (index == 0) {
                     data_->bios_vendor = move(value);
+                }
+                if (index == 1) {
+                    data_->bios_address = move(value);
                 }
                 break;
             }

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -4,6 +4,7 @@
 #include <internal/sources/dmi_source.hpp>
 #include <internal/sources/cpuid_source.hpp>
 #include <internal/detectors/virtualbox_detector.hpp>
+#include <internal/detectors/vmware_detector.hpp>
 #include <leatherman/logging/logging.hpp>
 
 using namespace std;
@@ -28,6 +29,12 @@ namespace whereami {
 
         if (virtualbox_result.valid()) {
             results.emplace_back(virtualbox_result);
+        }
+
+        auto vmware_result = detectors::vmware(cpuid_source, dmi_source);
+
+        if (vmware_result.valid()) {
+            results.emplace_back(vmware_result);
         }
 
         return results;

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_CASES
     "detectors/metadata.cc"
     "detectors/result.cc"
     "detectors/virtualbox_detector.cc"
+    "detectors/vmware_detector.cc"
     "fixtures.cc"
     "fixtures/cpuid_fixtures.cc"
     "fixtures/dmi_fixtures.cc"

--- a/lib/tests/detectors/virtualbox_detector.cc
+++ b/lib/tests/detectors/virtualbox_detector.cc
@@ -17,6 +17,7 @@ SCENARIO("Using the VirtualBox detector") {
             {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
         });
         dmi_fixture_values dmi_source({
+            "0x30000",
             "VirtualBox",
             "VirtualBox",
             "Oracle Corporation",
@@ -42,6 +43,7 @@ SCENARIO("Using the VirtualBox detector") {
             {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
         });
         dmi_fixture_values dmi_source({
+            "",
             "VirtualBox",
             "VirtualBox",
             "Oracle Corporation",
@@ -76,6 +78,7 @@ SCENARIO("Using the VirtualBox detector") {
             {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT}
         });
         dmi_fixture_values dmi_source({
+            "Other",
             "Other",
             "Other",
             "Other",

--- a/lib/tests/detectors/vmware_detector.cc
+++ b/lib/tests/detectors/vmware_detector.cc
@@ -1,0 +1,90 @@
+#include <catch.hpp>
+#include <internal/detectors/vmware_detector.hpp>
+#include "../fixtures/cpuid_fixtures.hpp"
+#include "../fixtures/dmi_fixtures.hpp"
+
+using namespace std;
+using namespace whereami::detectors;
+using namespace whereami::sources;
+using namespace whereami::testing::cpuid;
+using namespace whereami::testing::dmi;
+
+SCENARIO("Using the VMware detector") {
+    WHEN("running as root on a Linux VMware guest") {
+        cpuid_fixture_values cpuid_source({
+            {VENDOR_LEAF,        register_fixtures::VENDOR_VMwareVMware},
+            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
+        });
+        dmi_fixture_values dmi_source({
+            "0xea580",
+            "Phoenix Technologies LTD",
+            "Intel Corporation",
+            "440BX Desktop Reference Platform",
+            "VMware, Inc.",
+            "VMware Virtual Platform",
+            {
+                "[MS_VM_CERT/SHA1/27d66596a61c48dd3dc7216fd715126e33f59ae7]",
+                "Welcome to the Virtual Machine",
+            }});
+        THEN("the result should be valid") {
+            auto res = vmware(cpuid_source, dmi_source);
+            REQUIRE(res.valid());
+        }
+        THEN("the result should contain version metdata") {
+            auto res = vmware(cpuid_source, dmi_source);
+            REQUIRE(res.get<string>("version") == "ESXi 6.5");
+        }
+    }
+
+    WHEN("running as a normal user on a Linux VMware guest") {
+        cpuid_fixture_values cpuid_source({
+            {VENDOR_LEAF,        register_fixtures::VENDOR_VMwareVMware},
+            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
+        });
+        dmi_fixture_values dmi_source({
+            "",
+            "Phoenix Technologies LTD",
+            "Intel Corporation",
+            "440BX Desktop Reference Platform",
+            "VMware, Inc.",
+            "VMware Virtual Platform",
+            {}});
+        THEN("it should return true") {
+            auto res = vmware(cpuid_source, dmi_source);
+            REQUIRE(res.valid());
+        }
+        THEN("it should not contain version metdata") {
+            auto res = vmware(cpuid_source, dmi_source);
+            REQUIRE(res.get<string>("version") == "");
+        }
+    }
+
+    WHEN("running in a Windows VMware guest") {
+        cpuid_fixture_values cpuid_source({
+            {VENDOR_LEAF,        register_fixtures::VENDOR_VMwareVMware},
+            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
+        });
+        dmi_fixture_empty dmi_source;
+        THEN("it should return true") {
+            REQUIRE(vmware(cpuid_source, dmi_source).valid());
+        }
+    }
+
+    WHEN("running outside of VMware") {
+        cpuid_fixture_values cpuid_source({
+            {VENDOR_LEAF, register_fixtures::VENDOR_KVMKVMKVM},
+            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
+        });
+        dmi_fixture_values dmi_source({
+            "Other",
+            "Other",
+            "Other",
+            "Other",
+            "Other",
+            "Other",
+            {}});
+        THEN("it should return false") {
+            REQUIRE_FALSE(vmware(cpuid_source, dmi_source).valid());
+        }
+    }
+}

--- a/lib/tests/fixtures/cpuid_fixtures.hpp
+++ b/lib/tests/fixtures/cpuid_fixtures.hpp
@@ -33,6 +33,7 @@ namespace whereami { namespace testing { namespace cpuid {
         static const sources::cpuid_registers VENDOR_NONE{0, 0, 0, 0};
         static const sources::cpuid_registers VENDOR_KVMKVMKVM{0, 1263359563, 1447775574, 77};
         static const sources::cpuid_registers VENDOR_VBoxVBoxVBox{0, 2020557398, 2020557398, 2020557398};
+        static const sources::cpuid_registers VENDOR_VMwareVMware{1073741840, 1635208534, 1297507698, 1701994871};
     }
 
     /**

--- a/lib/tests/fixtures/dmi_fixtures.cc
+++ b/lib/tests/fixtures/dmi_fixtures.cc
@@ -6,7 +6,7 @@ using namespace std;
 
 namespace whereami { namespace testing { namespace dmi {
 
-    dmi_fixture::dmi_fixture(std::string dmidecode_path, std::string sys_path)
+    dmi_fixture::dmi_fixture(std::string const& dmidecode_path, std::string const& sys_path)
         : dmidecode_fixture_path_(dmidecode_path), sys_fixture_path_(sys_path)
     {
         data_.reset(nullptr);

--- a/lib/tests/fixtures/dmi_fixtures.hpp
+++ b/lib/tests/fixtures/dmi_fixtures.hpp
@@ -23,8 +23,8 @@ namespace whereami { namespace testing { namespace dmi {
      */
     class dmi_fixture : public sources::dmi {
     public:
-        dmi_fixture(std::string dmidecode_path = dmi_fixtures::DMIDECODE_NONE,
-                    std::string sys_path       = dmi_fixtures::SYS_NONE);
+        dmi_fixture(std::string const& dmidecode_path = dmi_fixtures::DMIDECODE_NONE,
+                    std::string const& sys_path       = dmi_fixtures::SYS_NONE);
     protected:
         /**
          * Read /sys/ data from a fixture base path (instead of from /sys/)

--- a/lib/tests/sources/dmi_source.cc
+++ b/lib/tests/sources/dmi_source.cc
@@ -17,14 +17,15 @@ SCENARIO("Using the DMI data source") {
             dmi_fixtures::DMIDECODE_NONE,
             dmi_fixtures::SYS_VIRTUALBOX
         };
-        THEN("string fields are populated via /sys/") {
+        THEN("accessible string fields are populated via /sys/") {
             REQUIRE(dmi_source.bios_vendor() == "innotek GmbH");
             REQUIRE(dmi_source.board_manufacturer() == "Oracle Corporation");
             REQUIRE(dmi_source.board_product_name() == "VirtualBox");
             REQUIRE(dmi_source.manufacturer() == "innotek GmbH");
             REQUIRE(dmi_source.product_name() == "VirtualBox");
         }
-        THEN("OEM strings are unavailable without dmidecode") {
+        THEN("privileged data is unavailable without dmidecode") {
+            REQUIRE(dmi_source.bios_address().empty());
             REQUIRE(dmi_source.oem_strings().size() == 0);
         }
     }
@@ -36,6 +37,7 @@ SCENARIO("Using the DMI data source") {
                 dmi_fixtures::SYS_NONE
             };
             THEN("nothing is found") {
+                REQUIRE(dmi_source.bios_address().empty());
                 REQUIRE(dmi_source.bios_vendor().empty());
                 REQUIRE(dmi_source.board_manufacturer().empty());
                 REQUIRE(dmi_source.board_product_name().empty());
@@ -51,6 +53,7 @@ SCENARIO("Using the DMI data source") {
                 dmi_fixtures::SYS_NONE
             };
             THEN("all fields are populated via dmidecode") {
+                REQUIRE(dmi_source.bios_address() == "0xE0000");
                 REQUIRE(dmi_source.bios_vendor() == "innotek GmbH");
                 REQUIRE(dmi_source.board_manufacturer() == "Oracle Corporation");
                 REQUIRE(dmi_source.board_product_name() == "VirtualBox");


### PR DESCRIPTION
Adds a new detector for VMware hypervisors.

The first commit adds a new item (BIOS address) to the set of data collected by the DMI detector. Determining the VMware version from inside a guest is tricky - there doesn't seem to be an official approach, but a few blog posts and repositories ([example](https://github.com/craigwatson/puppet-vmwaretools/blob/7b8caf14ab54d715622f37b67ba57bcae7c68be2/lib/facter/esx_version.rb), [and another](https://github.com/wolfspyre/vmware_puppetfact)) describe how the BIOS Address can be translated into a version - I included what translations I could find in `vmware_detector.cc`, but there are doubtless many others that could be added. This version information is also only available to root, since getting the BIOS address requires `dmidecode`.

The second commit adds the vmware detector; This is really similar to the existing VirtualBox detector.