### PR TITLE
(maint) Exclude noisy files from coverage

### DIFF
--- a/.travis_target.sh
+++ b/.travis_target.sh
@@ -44,7 +44,7 @@ else
   # Disable coveralls for private repos
   if [ ${TRAVIS_TARGET} == DEBUG ]; then
     # Ignore coveralls failures, keep service success uncoupled
-    coveralls --gcov gcov-4.8 --gcov-options '\-lp' >/dev/null || true
+    coveralls --gcov gcov-4.8 --gcov-options '\-lp' --exclude lib/src/whereami.cc >/dev/null || true
   fi
 fi
 


### PR DESCRIPTION
The main entrypoint will likely never have proper coverage, so
we exclude it.