### PR TITLE
(FACT-1674) Add systemd-nspawn detector

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PROJECT_SOURCES
     "src/detectors/result.cc"
     "src/detectors/docker_detector.cc"
     "src/detectors/lxc_detector.cc"
+    "src/detectors/nspawn_detector.cc"
     "src/detectors/virtualbox_detector.cc"
     "src/detectors/vmware_detector.cc"
     "src/sources/cgroup_source.cc"

--- a/lib/inc/internal/detectors/nspawn_detector.hpp
+++ b/lib/inc/internal/detectors/nspawn_detector.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <internal/detectors/result.hpp>
+#include <internal/sources/cgroup_source.hpp>
+
+namespace whereami { namespace detectors {
+
+    /**
+     * systemd-nspawn detector function
+     * @param cgroup_source A cgroup data source
+     * @return The systemd-nspawn detection result
+     */
+    result nspawn(sources::cgroup_base& cgroup_source);
+
+}}  // namespace whereami::detectors

--- a/lib/src/detectors/nspawn_detector.cc
+++ b/lib/src/detectors/nspawn_detector.cc
@@ -1,0 +1,30 @@
+#include <internal/detectors/nspawn_detector.hpp>
+#include <internal/vm.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <leatherman/util/regex.hpp>
+
+using namespace leatherman::util;
+using namespace std;
+using namespace whereami;
+
+namespace whereami { namespace detectors {
+
+    result nspawn(sources::cgroup_base& cgroup_source)
+    {
+        static const boost::regex nspawn_pattern {R"(machine\.slice\/machine-(.+)\.scope$)"};
+
+        result res { vm::systemd_nspawn };
+        string container_name;
+
+        for (auto const& path : cgroup_source.paths()) {
+            if (re_search(path, nspawn_pattern, &container_name)) {
+                res.validate();
+                res.set("name", container_name);
+                return res;
+            }
+        }
+
+        return res;
+    }
+
+}}

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_CASES
     "detectors/result.cc"
     "detectors/docker_detector.cc"
     "detectors/lxc_detector.cc"
+    "detectors/nspawn_detector.cc"
     "detectors/virtualbox_detector.cc"
     "detectors/vmware_detector.cc"
     "fixtures.cc"

--- a/lib/tests/detectors/nspawn_detector.cc
+++ b/lib/tests/detectors/nspawn_detector.cc
@@ -1,0 +1,37 @@
+#include <catch.hpp>
+#include <internal/detectors/nspawn_detector.hpp>
+#include "../fixtures/cgroup_fixtures.hpp"
+
+using namespace std;
+using namespace whereami::detectors;
+using namespace whereami::sources;
+using namespace whereami::testing::cgroup;
+
+SCENARIO("Using the systemd-nspawn detector") {
+    WHEN("running in an nspawn container") {
+        cgroup_fixture_values cgroup_source({ "/machine.slice/machine-fedora.scope", "/" });
+        auto res = nspawn(cgroup_source);
+        THEN("nspawn is detected") {
+            REQUIRE(res.valid());
+        }
+        THEN("the machine's name is collected") {
+            REQUIRE(res.get<string>("name") == "fedora");
+        }
+    }
+
+    WHEN("running where /proc/1/cgroup is unavailable") {
+        cgroup_fixture_empty cgroup_source;
+        auto res = nspawn(cgroup_source);
+        THEN("nspawn is not detected") {
+            REQUIRE_FALSE(res.valid());
+        }
+    }
+
+    WHEN("running in another type of container") {
+        cgroup_fixture_values cgroup_source({ "/docker/abcdef", "/docker" });
+        auto res = nspawn(cgroup_source);
+        THEN("nspawn is not detected") {
+            REQUIRE_FALSE(res.valid());
+        }
+    }
+}


### PR DESCRIPTION
Adds a detector for systemd-nspawn containers; Relies on /proc/1/cgroup
via the cgroup data source, which should contain paths like
`machine.slice/machine-<container name>.scope`. The result includes a
container name metadata value.