### PR TITLE
(FACT-1673) Add LXC detector

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,6 +22,7 @@ set(PROJECT_SOURCES
     "src/detectors/metadata.cc"
     "src/detectors/result.cc"
     "src/detectors/docker_detector.cc"
+    "src/detectors/lxc_detector.cc"
     "src/detectors/virtualbox_detector.cc"
     "src/detectors/vmware_detector.cc"
     "src/sources/cgroup_source.cc"

--- a/lib/inc/internal/detectors/lxc_detector.hpp
+++ b/lib/inc/internal/detectors/lxc_detector.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <internal/detectors/result.hpp>
+#include <internal/sources/cgroup_source.hpp>
+
+namespace whereami { namespace detectors {
+
+    /**
+     * LXC detector function
+     * @param cgroup_source A cgroup data source
+     * @return the LXC result
+     */
+    result lxc(sources::cgroup_base& cgroup_source);
+
+}}  // namespace whereami::detectors

--- a/lib/src/detectors/lxc_detector.cc
+++ b/lib/src/detectors/lxc_detector.cc
@@ -1,0 +1,29 @@
+#include <internal/detectors/lxc_detector.hpp>
+#include <internal/vm.hpp>
+#include <leatherman/util/regex.hpp>
+
+using namespace leatherman::util;
+using namespace std;
+using namespace whereami;
+
+namespace whereami { namespace detectors {
+
+    result lxc(sources::cgroup_base& cgroup_source)
+    {
+        static const boost::regex lxc_pattern { R"(^\/lxc\/([^/]+))" };
+
+        result res {vm::lxc};
+        string container_name;
+
+        for (auto const& path : cgroup_source.paths()) {
+            if (re_search(path, lxc_pattern, &container_name)) {
+                res.validate();
+                res.set("name", container_name);
+                return res;
+            }
+        }
+
+        return res;
+    }
+
+}}  // namespace whereami::detectors

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -5,6 +5,7 @@
 #include <internal/sources/cgroup_source.hpp>
 #include <internal/sources/cpuid_source.hpp>
 #include <internal/detectors/docker_detector.hpp>
+#include <internal/detectors/lxc_detector.hpp>
 #include <internal/detectors/virtualbox_detector.hpp>
 #include <internal/detectors/vmware_detector.hpp>
 #include <leatherman/logging/logging.hpp>
@@ -44,6 +45,12 @@ namespace whereami {
 
         if (docker_result.valid()) {
             results.emplace_back(docker_result);
+        }
+
+        auto lxc_result = detectors::lxc(cgroup_source);
+
+        if (lxc_result.valid()) {
+            results.emplace_back(lxc_result);
         }
 
         return results;

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_CASES
     "detectors/metadata.cc"
     "detectors/result.cc"
     "detectors/docker_detector.cc"
+    "detectors/lxc_detector.cc"
     "detectors/virtualbox_detector.cc"
     "detectors/vmware_detector.cc"
     "fixtures.cc"

--- a/lib/tests/detectors/lxc_detector.cc
+++ b/lib/tests/detectors/lxc_detector.cc
@@ -1,0 +1,37 @@
+#include <catch.hpp>
+#include <internal/detectors/lxc_detector.hpp>
+#include "../fixtures/cgroup_fixtures.hpp"
+
+using namespace std;
+using namespace whereami::detectors;
+using namespace whereami::sources;
+using namespace whereami::testing::cgroup;
+
+SCENARIO("Using the LXC detector") {
+    WHEN("running in an LXC container") {
+        cgroup_fixture_values cgroup_source({ "/lxc/name/init.scope" });
+        auto res = lxc(cgroup_source);
+        THEN("LXC is detected") {
+            REQUIRE(res.valid());
+        }
+        THEN("the container's name is collected") {
+            REQUIRE(res.get<std::string>("name") == "name");
+        }
+    }
+
+    WHEN("running where /proc/1/cgroup is unavailable") {
+        cgroup_fixture_empty cgroup_source;
+        auto res = lxc(cgroup_source);
+        THEN("LXC is not detected") {
+            REQUIRE_FALSE(res.valid());
+        }
+    }
+
+    WHEN("running in another type of container") {
+        cgroup_fixture_values cgroup_source({ "/machine.slice/machine-name.scope", "/" });
+        auto res = lxc(cgroup_source);
+        THEN("LXC is not detected") {
+            REQUIRE_FALSE(res.valid());
+        }
+    }
+}


### PR DESCRIPTION
Adds a detector for LXC containers; Relies on /proc/1/cgroup via the cgroup
data source, which should contain paths like `lxc/<container name>/init.scope`.
The result includes a container name metadata value.