### PR TITLE
(maint) Refactor DMI data source

### DIFF
--- a/lib/inc/internal/detectors/virtualbox_detector.hpp
+++ b/lib/inc/internal/detectors/virtualbox_detector.hpp
@@ -13,6 +13,6 @@ namespace whereami { namespace detectors {
      * @return Whether this machine is a VirtualBox guest
      */
     result virtualbox(const sources::cpuid_base& cpuid_source,
-                      const sources::dmi_base& dmi_source);
+                      sources::dmi_base& dmi_source);
 
 }}  // namespace whereami::detectors

--- a/lib/inc/internal/detectors/vmware_detector.hpp
+++ b/lib/inc/internal/detectors/vmware_detector.hpp
@@ -14,6 +14,6 @@ namespace whereami { namespace detectors {
      * @return The VMware detection result
      */
     result vmware(const sources::cpuid_base& cpuid_source,
-                  const sources::dmi_base& dmi_source);
+                  sources::dmi_base& dmi_source);
 
 }}  // namespace whereami::detectors

--- a/lib/inc/internal/sources/dmi_source.hpp
+++ b/lib/inc/internal/sources/dmi_source.hpp
@@ -54,75 +54,72 @@ namespace whereami { namespace sources {
     class dmi_base
     {
     public:
-        dmi_base() {}
-        virtual ~dmi_base() {}
         /**
          * Retrieve the BIOS address
          * @return The BIOS address
          */
-        std::string bios_address() const;
+        std::string bios_address();
         /**
          * Retrieve the BIOS vendor
          * @return The BIOS vendor's name
          */
-        std::string bios_vendor() const;
+        std::string bios_vendor();
         /**
          * Retrieve the board manufacturer
          * @return The board manufacturer's name
          */
-        std::string board_manufacturer() const;
+        std::string board_manufacturer();
         /**
          * Retrieve the board product name
          * @return The board product name
          */
-        std::string board_product_name() const;
+        std::string board_product_name();
         /**
          * Retrieve the system manufacturer
          * @return The system manufacturer
          */
-        std::string manufacturer() const;
+        std::string manufacturer();
         /**
          * Retrieve the product name
          * @return The product name
          */
-        std::string product_name() const;
+        std::string product_name();
         /**
          * Retrieve any OEM strings
          * @return A vector of OEM strings
          */
-        std::vector<std::string> oem_strings() const;
+        std::vector<std::string> oem_strings();
+
     protected:
+        /**
+         * /sys path to user-accessible DMI files on *nix systems
+         */
+        constexpr static char const* SYS_PATH {"/sys/class/dmi/id/"};
         /**
          * Collected data for this machine based on DMI information
          */
         std::unique_ptr<dmi_data> data_;
-    };
-
-    /**
-     * Default DMI data source
-     */
-    class dmi : public dmi_base
-    {
-     public:
-        dmi();
-        virtual ~dmi() {}
-     protected:
         /**
-         * /sys path to user-accessible DMI files on *nix systems
+         * Collect data if it hasn't been collected yet, and return a pointer to the DMI data object
+         * @return A pointer to the collected DMI data
          */
-        constexpr static char const* SYS_PATH = "/sys/class/dmi/id/";
-        /**
-         * Attempt to collect virtualization data using DMI
-         */
-        virtual void collect_data();
+        virtual dmi_data const* data();
         /**
          * Attempt to collect data from files in /sys/class/dmi/id/
+         * @return Whether data was collected
          */
-        virtual void collect_data_from_sys();
+        virtual bool collect_data_from_sys();
         /**
          * Attempt to collect data from dmidecode executable (requires root)
+         * @return Whether data was collected
          */
-        virtual void collect_data_from_dmidecode();
+        virtual bool collect_data_from_dmidecode();
+        /**
+         * Examine a line of dmidecode output for useful information
+         * @param line The contents of the line
+         * @param dmi_type Initial dmi_type value, e.g. -1
+         */
+        void parse_dmidecode_line(std::string& line, int& dmi_type);
         /**
          * Construct a full pathname for files in /sys/class/dmi/id/
          * @param filename The name of the file expected to exist in /sys/class/dmi/id/, e.g. "bios_vendor"
@@ -130,17 +127,16 @@ namespace whereami { namespace sources {
          */
         virtual std::string sys_path(std::string const& filename = "") const;
         /**
-         * Read a single DMI file
+         * Read a single DMI file from SYS_PATH
          * @param path The path to the file
          * @return The contents of the file
          */
         std::string read_file(std::string const& path);
-        /**
-         * Examine a line of dmidecode output for useful information
-         * @param line The contents of the line
-         * @param dmi_type Initial dmi_type value, e.g. -1
-         */
-        void parse_dmidecode_line(std::string& line, int& dmi_type);
     };
+
+    /**
+     * Default DMI source; Requires nothing beyond the base.
+     */
+    using dmi = dmi_base;
 
 }}  // namespace whereami::sources

--- a/lib/src/detectors/virtualbox_detector.cc
+++ b/lib/src/detectors/virtualbox_detector.cc
@@ -10,7 +10,7 @@ using namespace leatherman::util;
 namespace whereami { namespace detectors {
 
     result virtualbox(const sources::cpuid_base& cpuid_source,
-                      const sources::dmi_base& dmi_source) {
+                      sources::dmi_base& dmi_source) {
         result res {vm::virtualbox};
 
         if (cpuid_source.vendor() == "VBoxVBoxVBox" ||
@@ -20,7 +20,7 @@ namespace whereami { namespace detectors {
             // Look for VirtualBox version and revision in DMI OEM strings
             auto oem_strings = dmi_source.oem_strings();
 
-            for (auto const& oem_string : dmi_source.oem_strings()) {
+            for (auto const& oem_string : oem_strings) {
                 if (boost::istarts_with(oem_string, "vboxVer_")) {
                     auto version = oem_string.substr(8, string::npos);
                     res.set("version", version);

--- a/lib/src/detectors/vmware_detector.cc
+++ b/lib/src/detectors/vmware_detector.cc
@@ -41,7 +41,7 @@ static string vmware_bios_address_to_version(int address)
 namespace whereami { namespace detectors {
 
     result vmware(const sources::cpuid_base& cpuid_source,
-                  const sources::dmi_base& dmi_source)
+                  sources::dmi_base& dmi_source)
     {
         result res {vm::vmware};
 

--- a/lib/tests/fixtures/dmi_fixtures.cc
+++ b/lib/tests/fixtures/dmi_fixtures.cc
@@ -6,32 +6,40 @@ using namespace std;
 
 namespace whereami { namespace testing { namespace dmi {
 
-    dmi_fixture::dmi_fixture(std::string const& dmidecode_path, std::string const& sys_path)
-        : dmidecode_fixture_path_(dmidecode_path), sys_fixture_path_(sys_path)
-    {
-        data_.reset(nullptr);
-        collect_data();
-    }
-
-    std::string dmi_fixture::sys_path(std::string const& filename = "") const
+    std::string dmi_fixture::sys_path(std::string const& filename) const
     {
         return fixture_root + sys_fixture_path_ + filename;
     }
 
-    void dmi_fixture::collect_data_from_dmidecode()
+    bool dmi_fixture::collect_data_from_dmidecode()
     {
-        int dmi_type = -1;
         std::string dmidecode_output;
-        if (!load_fixture(dmidecode_fixture_path_, dmidecode_output)) return;
+
+        if (!load_fixture(dmidecode_fixture_path_, dmidecode_output)) {
+            return false;
+        }
+
+        int dmi_type {-1};
+
         leatherman::util::each_line(dmidecode_output, [&](string& line) {
             parse_dmidecode_line(line, dmi_type);
             return true;
         });
+
+        return data_.get() != nullptr;
     }
 
     dmi_fixture_values::dmi_fixture_values(sources::dmi_data&& data)
     {
         data_.reset(new dmi_data(move(data)));
+    }
+
+    dmi_data const* dmi_fixture_empty::data()
+    {
+        if (!data_) {
+            data_.reset(new dmi_data);
+        }
+        return data_.get();
     }
 
 }}}  // namespace whereami::testing::dmi

--- a/lib/tests/fixtures/dmi_fixtures.hpp
+++ b/lib/tests/fixtures/dmi_fixtures.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "../fixtures.hpp"
 #include <internal/sources/dmi_source.hpp>
 #include <leatherman/util/strings.hpp>
@@ -6,36 +8,39 @@
 
 namespace whereami { namespace testing { namespace dmi {
 
-    using dmi_fixture_empty = sources::dmi_base;
-
-    /**
-     * Common fixture paths within the fixture base path
-     */
-    namespace dmi_fixtures {
-        static const std::string SYS_NONE = "<none>";
-        static const std::string SYS_VIRTUALBOX = "sys/dmi/virtualbox/";
-        static const std::string DMIDECODE_NONE = "dmidecode/none.txt";
-        static const std::string DMIDECODE_VIRTUALBOX = "dmidecode/virtualbox.txt";
-    }
-
     /**
      * DMI data source relying on fixtures for dmidecode output and /sys/class/dmi/id/ files
      */
-    class dmi_fixture : public sources::dmi {
+    class dmi_fixture : public sources::dmi_base {
     public:
-        dmi_fixture(std::string const& dmidecode_path = dmi_fixtures::DMIDECODE_NONE,
-                    std::string const& sys_path       = dmi_fixtures::SYS_NONE);
+        /**
+         * Common fixture paths within the fixture base path
+         */
+        constexpr static char const* SYS_NONE  {"<none>"};
+        constexpr static char const* SYS_VIRTUALBOX {"sys/dmi/virtualbox/"};
+        constexpr static char const* DMIDECODE_NONE {"dmidecode/none.txt"};
+        constexpr static char const* DMIDECODE_VIRTUALBOX {"dmidecode/virtualbox.txt"};
+        /**
+         * Constructor specifying paths to fixture for /sys files and dmi output
+         * @param dmidecode_path
+         * @param sys_path
+         */
+        explicit dmi_fixture(std::string dmidecode_path = DMIDECODE_NONE,
+                             std::string sys_path       = SYS_NONE)
+            : dmidecode_fixture_path_(std::move(dmidecode_path)),
+              sys_fixture_path_(std::move(sys_path)) { }
+
     protected:
         /**
          * Read /sys/ data from a fixture base path (instead of from /sys/)
          * @return
          */
-        std::string sys_path(std::string const&) const override;
+        std::string sys_path(std::string const& filename = "") const override;
         /**
-         * Read dmidecode data from a fixture file (instead of the dmidecode executable output)
+         * Read dmidecode output data from a fixture file
          * @return
          */
-        void collect_data_from_dmidecode() override;
+        bool collect_data_from_dmidecode() override;
         /**
          * The dmidecode fixture file path
          */
@@ -51,8 +56,12 @@ namespace whereami { namespace testing { namespace dmi {
      */
     class dmi_fixture_values : public sources::dmi_base {
     public:
-        dmi_fixture_values(sources::dmi_data&& data);
-        ~dmi_fixture_values() {}
+        explicit dmi_fixture_values(sources::dmi_data&& data);
+    };
+
+    class dmi_fixture_empty : public sources::dmi_base {
+    protected:
+        sources::dmi_data const* data() override;
     };
 
 }}}  // namespace whereami::testing::dmi

--- a/lib/tests/sources/dmi_source.cc
+++ b/lib/tests/sources/dmi_source.cc
@@ -14,8 +14,8 @@ using namespace whereami::testing::dmi;
 SCENARIO("Using the DMI data source") {
     WHEN("DMI data is read from /sys/class/dmi/id/") {
         dmi_fixture dmi_source {
-            dmi_fixtures::DMIDECODE_NONE,
-            dmi_fixtures::SYS_VIRTUALBOX
+            dmi_fixture::DMIDECODE_NONE,
+            dmi_fixture::SYS_VIRTUALBOX
         };
         THEN("accessible string fields are populated via /sys/") {
             REQUIRE(dmi_source.bios_vendor() == "innotek GmbH");
@@ -33,8 +33,8 @@ SCENARIO("Using the DMI data source") {
     WHEN("DMI data is read from dmidecode") {
         AND_WHEN("output exists but there is no data available") {
             dmi_fixture dmi_source {
-                dmi_fixtures::DMIDECODE_NONE,
-                dmi_fixtures::SYS_NONE
+                dmi_fixture::DMIDECODE_NONE,
+                dmi_fixture::SYS_NONE
             };
             THEN("nothing is found") {
                 REQUIRE(dmi_source.bios_address().empty());
@@ -49,8 +49,8 @@ SCENARIO("Using the DMI data source") {
 
         AND_WHEN("output exists and data is available") {
             dmi_fixture dmi_source {
-                dmi_fixtures::DMIDECODE_VIRTUALBOX,
-                dmi_fixtures::SYS_NONE
+                dmi_fixture::DMIDECODE_VIRTUALBOX,
+                dmi_fixture::SYS_NONE
             };
             THEN("all fields are populated via dmidecode") {
                 REQUIRE(dmi_source.bios_address() == "0xE0000");


### PR DESCRIPTION
Previously, the DMI data source collected data in its constructor, so
even when DMI wouldn't have been used anyway, it would still try to
collect its data from dmidecode and /sys on instantiation. This commit
changes the DMI source so that it only collects data when one of data
values is accessed.