### PR TITLE
(FACT-1656) Add KVM detector

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PROJECT_SOURCES
     "src/detectors/openvz_detector.cc"
     "src/detectors/result.cc"
     "src/detectors/docker_detector.cc"
+    "src/detectors/kvm_detector.cc"
     "src/detectors/lxc_detector.cc"
     "src/detectors/nspawn_detector.cc"
     "src/detectors/virtualbox_detector.cc"

--- a/lib/inc/internal/detectors/kvm_detector.hpp
+++ b/lib/inc/internal/detectors/kvm_detector.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <internal/detectors/result.hpp>
+#include <internal/sources/cpuid_source.hpp>
+#include <internal/sources/dmi_source.hpp>
+
+namespace whereami { namespace detectors {
+
+    /**
+     * KVM detector function
+     * @param cpuid_source A CPUID data source
+     * @param dmi_source A DMI data source
+     * @return the KVM result
+     */
+    result kvm(const sources::cpuid_base& cpuid_source,
+               sources::dmi_base& dmi_source);
+
+}}  // namespace whereami::detectors

--- a/lib/src/detectors/kvm_detector.cc
+++ b/lib/src/detectors/kvm_detector.cc
@@ -1,0 +1,27 @@
+#include <internal/detectors/kvm_detector.hpp>
+#include <internal/vm.hpp>
+#include <leatherman/util/regex.hpp>
+
+using namespace leatherman::util;
+
+namespace whereami { namespace detectors {
+
+    static const boost::regex parallels_pattern {"^Parallels"};
+
+    result kvm(const sources::cpuid_base& cpuid_source,
+               sources::dmi_base& dmi_source)
+    {
+        result res {vm::kvm};
+
+        // dmidecode under KVM typically reports QEMU, but CPUID does report KVM.
+        // VirtualBox and Parallels will also report KVM in CPUID, though, so make sure they're not here.
+        if (cpuid_source.vendor() == "KVMKVMKVM"
+            && dmi_source.product_name() != "VirtualBox"
+            && !re_search(dmi_source.product_name(), parallels_pattern)) {
+            res.validate();
+        }
+
+        return res;
+    }
+
+}}  // namespace whereami::detectors

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -5,6 +5,7 @@
 #include <internal/sources/cgroup_source.hpp>
 #include <internal/sources/cpuid_source.hpp>
 #include <internal/detectors/docker_detector.hpp>
+#include <internal/detectors/kvm_detector.hpp>
 #include <internal/detectors/lxc_detector.hpp>
 #include <internal/detectors/openvz_detector.hpp>
 #include <internal/detectors/virtualbox_detector.hpp>
@@ -58,6 +59,12 @@ namespace whereami {
 
         if (openvz_result.valid()) {
             results.emplace_back(openvz_result);
+        }
+
+        auto kvm_result = detectors::kvm(cpuid_source, dmi_source);
+
+        if (kvm_result.valid()) {
+            results.emplace_back(kvm_result);
         }
 
         return results;

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_CASES
     "detectors/openvz_detector.cc"
     "detectors/result.cc"
     "detectors/docker_detector.cc"
+    "detectors/kvm_detector.cc"
     "detectors/lxc_detector.cc"
     "detectors/nspawn_detector.cc"
     "detectors/virtualbox_detector.cc"

--- a/lib/tests/detectors/kvm_detector.cc
+++ b/lib/tests/detectors/kvm_detector.cc
@@ -1,0 +1,95 @@
+#include <catch.hpp>
+#include <internal/detectors/kvm_detector.hpp>
+#include "../fixtures/cpuid_fixtures.hpp"
+#include "../fixtures/dmi_fixtures.hpp"
+
+using namespace std;
+using namespace whereami::detectors;
+using namespace whereami::sources;
+using namespace whereami::testing::dmi;
+using namespace whereami::testing::cpuid;
+
+SCENARIO("Using the KVM detector") {
+    WHEN("running on a KVM guest") {
+        cpuid_fixture_values cpuid_source({
+            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
+            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
+        });
+        dmi_fixture_values dmi_source({
+            "0xe8000",
+            "SeaBIOS",
+            "",
+            "",
+            "QEMU",
+            "Standard PC (i440FX + PIIX, 1996)",
+            {},
+        });
+        auto res = kvm(cpuid_source, dmi_source);
+        THEN("KVM is detected") {
+            REQUIRE(res.valid());
+        }
+    }
+
+    WHEN("running on a VirtualBox guest") {
+        cpuid_fixture_values cpuid_source({
+            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
+            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
+        });
+        dmi_fixture_values dmi_source({
+            "0x30000",
+            "VirtualBox",
+            "VirtualBox",
+            "Oracle Corporation",
+            "innotek GmbH",
+            "VirtualBox",
+            {
+                "vboxVer_5.1.22",
+                "vboxRev_115126",
+            },
+        });
+        auto res = kvm(cpuid_source, dmi_source);
+        THEN("KVM is not detected") {
+            REQUIRE_FALSE(res.valid());
+        }
+    }
+
+    WHEN("running on QEMU without KVM") {
+        cpuid_fixture_values cpuid_source({
+            {VENDOR_LEAF,        register_fixtures::VENDOR_AUTHENTICAMD},
+            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
+        });
+        dmi_fixture_values dmi_source({
+            "0xe8000",
+            "SeaBIOS",
+            "",
+            "",
+            "QEMU",
+            "Standard PC (i440FX + PIIX, 1996)",
+            {},
+        });
+        auto res = kvm(cpuid_source, dmi_source);
+        THEN("KVM is not detected") {
+            REQUIRE_FALSE(res.valid());
+        }
+    }
+
+    WHEN("running on a Parallels guest") {
+        cpuid_fixture_values cpuid_source({
+            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
+            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
+        });
+        dmi_fixture_values dmi_source({
+            "",
+            "Parallels Software International Inc.",
+            "Parallels Software International Inc.",
+            "Parallels Virtual Platform",
+            "Parallels Software International Inc.",
+            "Parallels Virtual Platform",
+            {},
+        });
+        auto res = kvm(cpuid_source, dmi_source);
+        THEN("KVM is not detected") {
+            REQUIRE_FALSE(res.valid());
+        }
+    }
+}

--- a/lib/tests/fixtures/cpuid_fixtures.hpp
+++ b/lib/tests/fixtures/cpuid_fixtures.hpp
@@ -31,6 +31,7 @@ namespace whereami { namespace testing { namespace cpuid {
         static const sources::cpuid_registers HYPERVISOR_ABSENT{0, 0, 0, 0};
         static const sources::cpuid_registers HYPERVISOR_PRESENT{0, 0, 3736609283, 0};
         static const sources::cpuid_registers VENDOR_NONE{0, 0, 0, 0};
+        static const sources::cpuid_registers VENDOR_AUTHENTICAMD{13, 1752462657, 1145913699, 1769238117};
         static const sources::cpuid_registers VENDOR_KVMKVMKVM{0, 1263359563, 1447775574, 77};
         static const sources::cpuid_registers VENDOR_VBoxVBoxVBox{0, 2020557398, 2020557398, 2020557398};
         static const sources::cpuid_registers VENDOR_VMwareVMware{1073741840, 1635208534, 1297507698, 1701994871};


### PR DESCRIPTION
Detects the presence of QEMU/KVM using CPUID and DMI. Includes no
metadata yet.