### PR TITLE
(FACT 1670) Add GCE metadata to KVM detector

### DIFF
--- a/lib/src/detectors/kvm_detector.cc
+++ b/lib/src/detectors/kvm_detector.cc
@@ -19,6 +19,10 @@ namespace whereami { namespace detectors {
             && dmi_source.product_name() != "VirtualBox"
             && !re_search(dmi_source.product_name(), parallels_pattern)) {
             res.validate();
+
+            if (dmi_source.bios_vendor() == "Google") {
+                res.set("google", true);
+            }
         }
 
         return res;

--- a/lib/tests/detectors/kvm_detector.cc
+++ b/lib/tests/detectors/kvm_detector.cc
@@ -92,4 +92,27 @@ SCENARIO("Using the KVM detector") {
             REQUIRE_FALSE(res.valid());
         }
     }
+
+    WHEN("Running on Google Compute Engine") {
+        cpuid_fixture_values cpuid_source({
+            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
+            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
+        });
+        dmi_fixture_values dmi_source({
+            "0xe8000",
+            "Google",
+            "Google",
+            "Google Compute Engine",
+            "Google",
+            "Google Compute Engine",
+            {},
+        });
+        auto res = kvm(cpuid_source, dmi_source);
+        THEN("KVM is detected") {
+            REQUIRE(res.valid());
+        }
+        THEN("Google Compute Engine is detected") {
+            REQUIRE(res.get<bool>("google"));
+        }
+    }
 }


### PR DESCRIPTION
Adds a boolean `google` metadata value to the KVM detection result,
reporting whether Google Compute Engine seems to be in use.