### PR TITLE
(FACT-1671) Add OpenStack metadata to KVM result

### DIFF
--- a/lib/src/detectors/kvm_detector.cc
+++ b/lib/src/detectors/kvm_detector.cc
@@ -6,6 +6,7 @@ using namespace leatherman::util;
 
 namespace whereami { namespace detectors {
 
+    static const boost::regex openstack_pattern {"^OpenStack"};
     static const boost::regex parallels_pattern {"^Parallels"};
 
     result kvm(const sources::cpuid_base& cpuid_source,
@@ -22,6 +23,10 @@ namespace whereami { namespace detectors {
 
             if (dmi_source.bios_vendor() == "Google") {
                 res.set("google", true);
+            }
+
+            if (re_search(dmi_source.product_name(), openstack_pattern)) {
+                res.set("openstack", true);
             }
         }
 

--- a/lib/tests/detectors/kvm_detector.cc
+++ b/lib/tests/detectors/kvm_detector.cc
@@ -115,4 +115,27 @@ SCENARIO("Using the KVM detector") {
             REQUIRE(res.get<bool>("google"));
         }
     }
+
+    WHEN("Running on OpenStack") {
+        cpuid_fixture_values cpuid_source({
+            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
+            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
+        });
+        dmi_fixture_values dmi_source({
+            "0xE8000",
+            "SeaBIOS",
+            "",
+            "",
+            "Fedora Project",
+            "OpenStack Nova",
+            {},
+        });
+        auto res = kvm(cpuid_source, dmi_source);
+        THEN("KVM is detected") {
+            REQUIRE(res.valid());
+        }
+        THEN("OpenStack is detected") {
+            REQUIRE(res.get<bool>("openstack"));
+        }
+    }
 }


### PR DESCRIPTION
Adds a boolean `openstack` metadata value to the KVM detection result, reporting whether OpenStack seems to be in use.

KVM is the default and only fully supported hypervisor for OpenStack, but others are at least [partially supported](https://wiki.openstack.org/wiki/HypervisorSupportMatrix) - I don't have a way to manually test those at the moment. It would be simple to add this type of check to other detector results, though; Maybe we can refactor this later if it seems like checking the DMI product name this way will work for other hypervisors, too.