### PR TITLE
(FACT-1663) Add Xen detector

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -29,6 +29,7 @@ set(PROJECT_SOURCES
     "src/detectors/nspawn_detector.cc"
     "src/detectors/virtualbox_detector.cc"
     "src/detectors/vmware_detector.cc"
+    "src/detectors/xen_detector.cc"
     "src/sources/cgroup_source.cc"
     "src/sources/cpuid_source.cc"
     "src/sources/dmi_source.cc"

--- a/lib/inc/internal/detectors/xen_detector.hpp
+++ b/lib/inc/internal/detectors/xen_detector.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <internal/detectors/result.hpp>
+#include <internal/sources/cpuid_source.hpp>
+#include <internal/sources/dmi_source.hpp>
+#include <csetjmp>
+#include <csignal>
+#include <string>
+
+namespace whereami { namespace detectors {
+
+    /**
+     * Xen detector function
+     * @param cpuid_source An instance of a CPUID data source
+     * @return The Xen detection result
+     */
+    result xen(const sources::cpuid& cpuid_source);
+
+    /**
+     * Path to the directory holding Xen's capabilities file.
+     * /proc/xen/capabilities contains the string "control_d" on dom0, and is absent on domU.
+     */
+    static const std::string xen_path {"proc/xen"};
+
+    /**
+     * Determine whether the current domain has a /proc/xen directory. This should be present on both PV and HVM.
+     * @return Whether /proc/xen is a directory
+     */
+    bool has_xen_path();
+
+    /**
+     * Determine whether the current domain is dom0 based on the presence of a /proc/xen/capabilities file
+     * @param root The root of the file system
+     * @return Whether the Xen capabilities file indicates dom0
+     */
+    bool is_xen_privileged(std::string root = "/");
+
+}}  // namespace whereami::detectors

--- a/lib/inc/internal/sources/cpuid_source.hpp
+++ b/lib/inc/internal/sources/cpuid_source.hpp
@@ -36,9 +36,10 @@ namespace whereami { namespace sources {
         /**
          * Call the cpuid instruction
          * @param leaf The value to pass into CPUID via eax; Determines the type of information returned
+         * @param subleaf The value to pass into CPUID via ecx; Used for additional options
          * @return Register object with results of the CPUID function
          */
-        virtual cpuid_registers read_cpuid(unsigned int leaf) const;
+        virtual cpuid_registers read_cpuid(unsigned int leaf, unsigned int subleaf = 0) const;
         /**
          * Determine whether CPUID reports that this system is running on a hypervisor (Calls CPUID with eax = 1)
          * @return whether CPUID reports a hypervisor
@@ -46,14 +47,15 @@ namespace whereami { namespace sources {
         bool has_hypervisor() const;
         /**
          * Retrieve the vendor ID (Calls CPUID with eax = VENDOR_LEAF)
+         * @param subleaf An optional subleaf value to pass through to read_cpuid
          * @return the vendor ID string
          */
-        std::string vendor() const;
+        std::string vendor(unsigned int subleaf = 0) const;
         /**
          * Most hypervisors store vendor information in this leaf
          * When this value is passed to CPUID, ebx, ecx, and edx report a vendor ID
          */
-        static const unsigned int VENDOR_LEAF = 0x40000000;
+        static const unsigned int VENDOR_LEAF {0x40000000};
         /**
          * When CPUID is passed a 1, bit 31 of ecx reports whether the machine is running on a hypervisor
          */

--- a/lib/inc/internal/sources/cpuid_source.hpp
+++ b/lib/inc/internal/sources/cpuid_source.hpp
@@ -46,6 +46,14 @@ namespace whereami { namespace sources {
          */
         bool has_hypervisor() const;
         /**
+         * Xen with HVM sometimes stores its vendor ID at a higher offset from the usual vendor leaf.
+         * Search for the given vendor id at offsets from the base leaf (in increments of 0x100) until the desired
+         * vendor string is found or the maximum leaf (which is the value returned by the CPUID instruction) is reached.
+         * @param vendor_search The vendor ID to search for
+         * @return Whether the vendor string was found at any offset
+         */
+        bool has_vendor(std::string const& vendor_search) const;
+        /**
          * Retrieve the vendor ID (Calls CPUID with eax = VENDOR_LEAF)
          * @param subleaf An optional subleaf value to pass through to read_cpuid
          * @return the vendor ID string
@@ -60,6 +68,14 @@ namespace whereami { namespace sources {
          * When CPUID is passed a 1, bit 31 of ecx reports whether the machine is running on a hypervisor
          */
         static const unsigned int HYPERVISOR_PRESENT = 1;
+
+    protected:
+        /**
+         * Interpret the values of ebx, ecx, and edx as a vendor ID string after a call to CPUID with the vendor leaf.
+         * @param regs Regsiter results from read_cpuid
+         * @return A vendor ID string
+         */
+        std::string interpret_vendor_registers(cpuid_registers const& regs) const;
     };
 
     /**

--- a/lib/src/detectors/xen_detector.cc
+++ b/lib/src/detectors/xen_detector.cc
@@ -1,0 +1,54 @@
+#include <internal/detectors/xen_detector.hpp>
+#include <leatherman/file_util/file.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <leatherman/util/regex.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string/trim.hpp>
+
+using namespace whereami::sources;
+using namespace leatherman::util;
+using namespace leatherman::file_util;
+using namespace boost::filesystem;
+using namespace std;
+
+namespace lth_file = leatherman::file_util;
+
+namespace whereami { namespace detectors {
+
+    bool has_xen_path() {
+        return exists(xen_path);
+    }
+
+    bool is_xen_privileged(string root) {
+        // dom0 and domU should both have a /proc/xen directory, but only hvm will have a capabilities file there
+        path capabilities_path {root + xen_path + "/capabilities"};
+        if (!is_regular_file(capabilities_path)) {
+            return false;
+        }
+
+        // The capabilities file contains "control_d" on dom0
+        std::string contents;
+        if (lth_file::read(capabilities_path.string(), contents)) {
+            boost::trim(contents);
+            return contents == "control_d";
+        }
+        return false;
+    }
+
+    result xen(const cpuid& cpuid_source) {
+        result res{"xen"};
+
+        if (!has_xen_path()) {
+            return res;
+        }
+
+        res.validate();
+        res.set("context", cpuid_source.has_vendor("XenVMMXenVMM") ? "hvm" : "pv");
+
+        // Determine whether this is dom0 or domU
+        res.set("privileged", is_xen_privileged());
+
+        return res;
+    }
+
+}}  // namespace whereami::detectors

--- a/lib/src/sources/cpuid_source.cc
+++ b/lib/src/sources/cpuid_source.cc
@@ -1,24 +1,21 @@
 #include <internal/sources/cpuid_source.hpp>
 
-using namespace std;
 using namespace whereami::sources;
+using namespace std;
 
 namespace whereami { namespace sources {
 
-#if defined(__x86_64__) || defined(__i386__)
-    cpuid_registers cpuid_base::read_cpuid(unsigned int leaf) const {
+    cpuid_registers cpuid_base::read_cpuid(unsigned int leaf, unsigned int subleaf) const {
         cpuid_registers result;
+#if defined(__x86_64__) || defined(__i386__)
+        // ebx is the PIC register in 32-bit environments; Don't clobber it
         asm volatile(
             "xchgl %%ebx,%1; xor %%ebx,%%ebx; cpuid; xchgl %%ebx,%1"
             : "=a" (result.eax), "=b" (result.ebx), "=c" (result.ecx), "=d" (result.edx)
-            : "a" (leaf), "c" (0));
+            : "a" (leaf), "c" (subleaf));
+#endif
         return result;
     }
-#else
-    cpuid_registers cpuid_base::read_cpuid(unsigned int leaf) const {
-        return {};
-    }
-#endif
 
     bool cpuid_base::has_hypervisor() const
     {
@@ -29,8 +26,22 @@ namespace whereami { namespace sources {
     string cpuid_base::vendor() const
     {
         auto regs = read_cpuid(VENDOR_LEAF);
-        unsigned int result[4] = {regs.ebx, regs.ecx, regs.edx, 0};
-        return string{reinterpret_cast<char*>(result)};
+        // CPUID returns the maximum useful leaf value in eax by default
+        unsigned int max_entries = regs.eax;
+
+        if (max_entries < 4 || max_entries >= 0x10000) {
+            return (interpret_vendor_registers(regs) == vendor_search);
+        }
+
+        for (unsigned int leaf = VENDOR_LEAF + 0x100;
+             leaf <= VENDOR_LEAF + max_entries;
+             leaf += 0x100) {
+            if (interpret_vendor_registers(read_cpuid(leaf)) == vendor_search) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 }}

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_CASES
     "detectors/nspawn_detector.cc"
     "detectors/virtualbox_detector.cc"
     "detectors/vmware_detector.cc"
+    "detectors/xen_detector.cc"
     "fixtures.cc"
     "fixtures/cpuid_fixtures.cc"
     "fixtures/dmi_fixtures.cc"

--- a/lib/tests/detectors/hyperv_detector.cc
+++ b/lib/tests/detectors/hyperv_detector.cc
@@ -10,14 +10,21 @@ using namespace whereami::testing::dmi;
 using namespace whereami::testing::cpuid;
 
 SCENARIO("Using the Hyper-V detector") {
-    cpuid_fixture_values cpuid_empty({
-        {VENDOR_LEAF,        register_fixtures::VENDOR_NONE},
-        {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT}
-    });
-    cpuid_fixture_values cpuid_source({
-        {VENDOR_LEAF,        register_fixtures::VENDOR_Microsoft_Hv},
-        {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-    });
+    leaf_register_map empty_values {
+        {VENDOR_LEAF, {
+            {0, register_fixtures::VENDOR_NONE}}},
+        {HYPERVISOR_PRESENT_LEAF, {
+            {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+
+    cpuid_fixture cpuid_empty(empty_values);
+
+    leaf_register_map hyperv_values {
+        {VENDOR_LEAF, {
+            {0, register_fixtures::VENDOR_Microsoft_Hv}}},
+        {HYPERVISOR_PRESENT_LEAF, {
+            {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+
+    cpuid_fixture cpuid_source(hyperv_values);
 
     dmi_fixture_values dmi_source({
         "",

--- a/lib/tests/detectors/kvm_detector.cc
+++ b/lib/tests/detectors/kvm_detector.cc
@@ -127,10 +127,12 @@ SCENARIO("Using the KVM detector") {
     }
 
     WHEN("Running on OpenStack") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                  {0, register_fixtures::VENDOR_KVMKVMKVM}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                  {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "0xE8000",
             "SeaBIOS",

--- a/lib/tests/detectors/kvm_detector.cc
+++ b/lib/tests/detectors/kvm_detector.cc
@@ -11,10 +11,12 @@ using namespace whereami::testing::cpuid;
 
 SCENARIO("Using the KVM detector") {
     WHEN("running on a KVM guest") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_KVMKVMKVM}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "0xe8000",
             "SeaBIOS",
@@ -31,10 +33,12 @@ SCENARIO("Using the KVM detector") {
     }
 
     WHEN("running on a VirtualBox guest") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_KVMKVMKVM}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "0x30000",
             "VirtualBox",
@@ -54,10 +58,12 @@ SCENARIO("Using the KVM detector") {
     }
 
     WHEN("running on QEMU without KVM") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_AUTHENTICAMD},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_AuthenticAMD}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "0xe8000",
             "SeaBIOS",
@@ -74,10 +80,12 @@ SCENARIO("Using the KVM detector") {
     }
 
     WHEN("running on a Parallels guest") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_KVMKVMKVM}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "",
             "Parallels Software International Inc.",
@@ -94,10 +102,12 @@ SCENARIO("Using the KVM detector") {
     }
 
     WHEN("Running on Google Compute Engine") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_KVMKVMKVM}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "0xe8000",
             "Google",

--- a/lib/tests/detectors/virtualbox_detector.cc
+++ b/lib/tests/detectors/virtualbox_detector.cc
@@ -12,10 +12,12 @@ using namespace whereami::testing::cpuid;
 
 SCENARIO("Using the VirtualBox detector") {
     WHEN("running on a Linux VirtualBox guest with root") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_KVMKVMKVM}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "0x30000",
             "VirtualBox",
@@ -38,10 +40,12 @@ SCENARIO("Using the VirtualBox detector") {
     }
 
     WHEN("running on a Linux VirtualBox guest without root") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_KVMKVMKVM}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "",
             "VirtualBox",
@@ -61,10 +65,12 @@ SCENARIO("Using the VirtualBox detector") {
     }
 
     WHEN("running on a Windows VirtualBox guest") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_VBoxVBoxVBox},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT}
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_VBoxVBoxVBox}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_empty dmi_source;
         THEN("the result should be valid") {
             auto res = virtualbox(cpuid_source, dmi_source);
@@ -73,10 +79,12 @@ SCENARIO("Using the VirtualBox detector") {
     }
 
     WHEN("running outside of VirtualBox") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_KVMKVMKVM},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT}
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_KVMKVMKVM}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "Other",
             "Other",

--- a/lib/tests/detectors/vmware_detector.cc
+++ b/lib/tests/detectors/vmware_detector.cc
@@ -11,10 +11,12 @@ using namespace whereami::testing::dmi;
 
 SCENARIO("Using the VMware detector") {
     WHEN("running as root on a Linux VMware guest") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_VMwareVMware},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_VMwareVMware}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "0xea580",
             "Phoenix Technologies LTD",
@@ -37,10 +39,12 @@ SCENARIO("Using the VMware detector") {
     }
 
     WHEN("running as a normal user on a Linux VMware guest") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_VMwareVMware},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_VMwareVMware}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "",
             "Phoenix Technologies LTD",
@@ -60,10 +64,12 @@ SCENARIO("Using the VMware detector") {
     }
 
     WHEN("running in a Windows VMware guest") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF,        register_fixtures::VENDOR_VMwareVMware},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_VMwareVMware}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_empty dmi_source;
         THEN("it should return true") {
             REQUIRE(vmware(cpuid_source, dmi_source).valid());
@@ -71,10 +77,12 @@ SCENARIO("Using the VMware detector") {
     }
 
     WHEN("running outside of VMware") {
-        cpuid_fixture_values cpuid_source({
-            {VENDOR_LEAF, register_fixtures::VENDOR_KVMKVMKVM},
-            {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
-        });
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_KVMKVMKVM}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_PRESENT}}}};
+        cpuid_fixture cpuid_source {values};
         dmi_fixture_values dmi_source({
             "Other",
             "Other",

--- a/lib/tests/detectors/xen_detector.cc
+++ b/lib/tests/detectors/xen_detector.cc
@@ -1,0 +1,20 @@
+#include <catch.hpp>
+#include <internal/detectors/xen_detector.hpp>
+#include "../fixtures/cpuid_fixtures.hpp"
+
+using namespace whereami::detectors;
+using namespace whereami::sources;
+using namespace whereami::testing;
+using namespace whereami::testing::cpuid;
+using namespace std;
+
+SCENARIO("Using the Xen detector") {
+    WHEN("Checking for dom0 privileges") {
+        THEN("a host with capabilities of 'control_d' is reported as privileged") {
+            REQUIRE(is_xen_privileged(fixture_full_path("filesystem/xen_detector/dom0_root/")));
+        }
+        THEN("a host without capabilities of 'control_d' is reported as unprivileged") {
+            REQUIRE_FALSE(is_xen_privileged(fixture_full_path("filesystem/xen_detector/domU_root/")));
+        }
+    }
+}

--- a/lib/tests/fixtures/cpuid_fixtures.cc
+++ b/lib/tests/fixtures/cpuid_fixtures.cc
@@ -6,23 +6,17 @@ using namespace std;
 
 namespace whereami { namespace testing { namespace cpuid {
 
-    cpuid_registers cpuid_fixture_empty::read_cpuid(unsigned int leaf) const
+    cpuid_registers cpuid_register_fixtures::lookup(unsigned int leaf, unsigned int subleaf) const
     {
-        return {};
-    }
-
-    cpuid_fixture_values::cpuid_fixture_values(std::unordered_map<unsigned int, sources::cpuid_registers> values)
-        : register_values_(std::move(values))
-    {
-    }
-
-    cpuid_registers cpuid_fixture_values::read_cpuid(unsigned int leaf) const
-    {
-        auto it = register_values_.find(leaf);
-        if (it == register_values_.end()) {
+        auto it_leaf = register_values_.find(leaf);
+        if (it_leaf == register_values_.end()) {
             return {};
         }
-        return it->second;
+        auto it_subleaf = it_leaf->second.find(subleaf);
+        if (it_subleaf == it_leaf->second.end()) {
+            return {};
+        }
+        return it_subleaf->second;
     }
 
 }}}  // namespace whereami::testing::cpuid

--- a/lib/tests/fixtures/cpuid_fixtures.hpp
+++ b/lib/tests/fixtures/cpuid_fixtures.hpp
@@ -1,24 +1,42 @@
-#include "../fixtures.hpp"
 #include <internal/sources/cpuid_source.hpp>
+#include "../fixtures.hpp"
 #include <unordered_map>
 
 namespace whereami { namespace testing { namespace cpuid {
 
     /**
-     * CPUID data source returning no usable information
+     * Mapping of CPUID leaf and subleaf values to returned register values
      */
-    class cpuid_fixture_empty : public sources::cpuid_base {
+    using leaf_register_map = std::unordered_map<unsigned int, std::unordered_map<unsigned int, sources::cpuid_registers>>;
+
+    class cpuid_register_fixtures {
     public:
-        sources::cpuid_registers read_cpuid(unsigned int leaf) const override;
+        /**
+         * @param values
+         */
+        cpuid_register_fixtures(leaf_register_map values) : register_values_(std::move(values)) {}
+        /**
+         * @param leaf
+         * @param subleaf
+         * @return
+         */
+        sources::cpuid_registers lookup(unsigned int leaf, unsigned int subleaf) const;
+    protected:
+        leaf_register_map register_values_;
     };
 
     /**
      * CPUID data source with predefined register results
      */
-    class cpuid_fixture_values : public sources::cpuid_base {
+    class cpuid_fixture : public sources::cpuid_base {
     public:
-        cpuid_fixture_values(std::unordered_map<unsigned int, sources::cpuid_registers> values);
-        sources::cpuid_registers read_cpuid(unsigned int leaf) const override;
+        cpuid_fixture(cpuid_register_fixtures values) : register_values_(std::move(values)) {};
+        sources::cpuid_registers read_cpuid(unsigned int leaf, unsigned int subleaf = 0) const override {
+            return register_values_.lookup(leaf, subleaf);
+        }
+    protected:
+        cpuid_register_fixtures register_values_;
+    };
 
     protected:
         std::unordered_map<unsigned int, sources::cpuid_registers> register_values_;
@@ -28,20 +46,23 @@ namespace whereami { namespace testing { namespace cpuid {
      * Expected raw register values
      */
     namespace register_fixtures {
-        static const sources::cpuid_registers HYPERVISOR_ABSENT{0, 0, 0, 0};
-        static const sources::cpuid_registers HYPERVISOR_PRESENT{0, 0, 3736609283, 0};
-        static const sources::cpuid_registers VENDOR_NONE{0, 0, 0, 0};
-        static const sources::cpuid_registers VENDOR_AUTHENTICAMD{13, 1752462657, 1145913699, 1769238117};
-        static const sources::cpuid_registers VENDOR_KVMKVMKVM{0, 1263359563, 1447775574, 77};
-        static const sources::cpuid_registers VENDOR_Microsoft_Hv{1073741830, 1919117645, 1718580079, 1984438388};
-        static const sources::cpuid_registers VENDOR_VBoxVBoxVBox{0, 2020557398, 2020557398, 2020557398};
-        static const sources::cpuid_registers VENDOR_VMwareVMware{1073741840, 1635208534, 1297507698, 1701994871};
+        static const sources::cpuid_registers HYPERVISOR_ABSENT {0, 0, 0, 0};
+        static const sources::cpuid_registers HYPERVISOR_PRESENT {0, 0, 3736609283, 0};
+        static const sources::cpuid_registers VENDOR_NONE {0, 0, 0, 0};
+        static const sources::cpuid_registers VENDOR_AuthenticAMD {13, 1752462657, 1769238117, 1145913699};
+        static const sources::cpuid_registers VENDOR_KVMKVMKVM {0, 1263359563, 1447775574, 77};
+        static const sources::cpuid_registers VENDOR_VBoxVBoxVBox {0, 2020557398, 2020557398, 2020557398};
+        static const sources::cpuid_registers VENDOR_VMwareVMware {1073741840, 1635208534, 1297507698, 1701994871};
+        static const sources::cpuid_registers VENDOR_XenVMMXenVMM {1073741828, 1450075480, 1700285773, 1296914030};
+        static const sources::cpuid_registers VERSION_XEN_48 {262152, 0, 0, 0};
+        static const sources::cpuid_registers XEN_INVALID {7, 832, 832, 0};
     }
 
     /**
      * Aliased here to allow use in cpuid fixture initialization lists
      */
-    static const unsigned int VENDOR_LEAF = sources::cpuid_base::VENDOR_LEAF;
-    static const unsigned int HYPERVISOR_PRESENT = sources::cpuid_base::HYPERVISOR_PRESENT;
+    static const unsigned int VENDOR_LEAF {sources::cpuid_base::VENDOR_LEAF};
+    static const unsigned int HYPERVISOR_PRESENT_LEAF {sources::cpuid_base::HYPERVISOR_PRESENT};
+    static const unsigned int XEN_VERSION_LEAF {sources::cpuid_xen::VERSION_LEAF};
 
 }}};  // namespace whereami::testing::cpuid

--- a/lib/tests/fixtures/cpuid_fixtures.hpp
+++ b/lib/tests/fixtures/cpuid_fixtures.hpp
@@ -38,10 +38,6 @@ namespace whereami { namespace testing { namespace cpuid {
         cpuid_register_fixtures register_values_;
     };
 
-    protected:
-        std::unordered_map<unsigned int, sources::cpuid_registers> register_values_;
-    };
-
     /**
      * Expected raw register values
      */
@@ -51,10 +47,11 @@ namespace whereami { namespace testing { namespace cpuid {
         static const sources::cpuid_registers VENDOR_NONE {0, 0, 0, 0};
         static const sources::cpuid_registers VENDOR_AuthenticAMD {13, 1752462657, 1769238117, 1145913699};
         static const sources::cpuid_registers VENDOR_KVMKVMKVM {0, 1263359563, 1447775574, 77};
+        static const sources::cpuid_registers VENDOR_Microsoft_Hv {1073741830, 1919117645, 1718580079, 1984438388};
         static const sources::cpuid_registers VENDOR_VBoxVBoxVBox {0, 2020557398, 2020557398, 2020557398};
         static const sources::cpuid_registers VENDOR_VMwareVMware {1073741840, 1635208534, 1297507698, 1701994871};
         static const sources::cpuid_registers VENDOR_XenVMMXenVMM {1073741828, 1450075480, 1700285773, 1296914030};
-        static const sources::cpuid_registers VERSION_XEN_48 {262152, 0, 0, 0};
+        static const sources::cpuid_registers XEN_OFFSET {65534, 832, 832, 0};
         static const sources::cpuid_registers XEN_INVALID {7, 832, 832, 0};
     }
 
@@ -63,6 +60,5 @@ namespace whereami { namespace testing { namespace cpuid {
      */
     static const unsigned int VENDOR_LEAF {sources::cpuid_base::VENDOR_LEAF};
     static const unsigned int HYPERVISOR_PRESENT_LEAF {sources::cpuid_base::HYPERVISOR_PRESENT};
-    static const unsigned int XEN_VERSION_LEAF {sources::cpuid_xen::VERSION_LEAF};
 
 }}};  // namespace whereami::testing::cpuid

--- a/lib/tests/fixtures/filesystem/xen_detector/dom0_root/proc/xen/capabilities
+++ b/lib/tests/fixtures/filesystem/xen_detector/dom0_root/proc/xen/capabilities
@@ -1,0 +1,1 @@
+control_d

--- a/lib/tests/sources/cpuid_source.cc
+++ b/lib/tests/sources/cpuid_source.cc
@@ -66,3 +66,28 @@ SCENARIO("Specifying a subleaf value") {
         }
     }
 }
+
+SCENARIO("Searching for a vendor ID at an offset leaf") {
+    WHEN("the desired ID sits at a higher leaf than the base") {
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::XEN_OFFSET}}},
+            {VENDOR_LEAF + 0x100, {
+                {0, register_fixtures::XEN_INVALID}}},
+            {VENDOR_LEAF + 0x200, {
+                {0, register_fixtures::VENDOR_XenVMMXenVMM}}}};
+        cpuid_fixture cpuid_source {values};
+        WHEN("the ID should be found") {
+            REQUIRE(cpuid_source.has_vendor("XenVMMXenVMM"));
+        }
+    }
+    WHEN("a higher-offset vendor ID exists but it does not match the desired ID") {
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::XEN_OFFSET}}}};
+        cpuid_fixture cpuid_source {values};
+        THEN("the ID should not be found") {
+            REQUIRE_FALSE(cpuid_source.has_vendor("XenVMMXenVMM"));
+        }
+    }
+}


### PR DESCRIPTION
The first commit changes the CPUID data source so that it's possible to supply a value for the ecx register (a subleaf) in addition to the eax leaf. This is required to get vendor and version information for Xen PV guests.

The second commit adds the Xen detector, which is based on Xen's [xen-detect.c](https://raw.githubusercontent.com/mirage/xen/master/tools/misc/xen-detect.c). To get a Xen vendor string out of CPUID in a PV context, one has to use a forced emulation prefix ([see here](https://xenbits.xen.org/docs/unstable/features/feature-levelling.html#xen-forced-emulation-prefix)), so there's a new specialized source for Xen (the drop in coverage comes from this addition).

For a valid result, metadata  includes:
- A `context` string ("pv" or "hvm")
- A `version` string, e.g. "4.8"
- A `privileged` bool, which is true for dom0 (this is not based on CPUID - instead it checks the `/proc/xen/capabilities` file, which contains 'control_d' on dom0)



Results from this detector match the results of `xen-detect.c` for PV and HVM Linux and Windows machines I tested manually, but I don't have a lot of Xen experience - advice is very welcome!
