### PR TITLE
(FACT-1667) Add Hyper-V detector

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,8 +30,12 @@ set(PROJECT_SOURCES
     "src/detectors/vmware_detector.cc"
     "src/sources/cgroup_source.cc"
     "src/sources/cpuid_source.cc"
-    "src/sources/smbios_base.cc"
-    "src/sources/dmi_source.cc")
+    "src/sources/dmi_source.cc"
+    "src/sources/smbios_base.cc")
+
+if(WIN32)
+    set(PROJECT_SOURCES ${PROJECT_SOURCES} "src/sources/wmi_source.cc")
+endif()
 
 ## An object target is generated that can be used by both the library and test executable targets.
 ## Without the intermediate target, unexported symbols can't be tested.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,6 +30,7 @@ set(PROJECT_SOURCES
     "src/detectors/vmware_detector.cc"
     "src/sources/cgroup_source.cc"
     "src/sources/cpuid_source.cc"
+    "src/sources/smbios_base.cc"
     "src/sources/dmi_source.cc")
 
 ## An object target is generated that can be used by both the library and test executable targets.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PROJECT_SOURCES
     "src/detectors/openvz_detector.cc"
     "src/detectors/result.cc"
     "src/detectors/docker_detector.cc"
+    "src/detectors/hyperv_detector.cc"
     "src/detectors/kvm_detector.cc"
     "src/detectors/lxc_detector.cc"
     "src/detectors/nspawn_detector.cc"

--- a/lib/inc/internal/detectors/hyperv_detector.hpp
+++ b/lib/inc/internal/detectors/hyperv_detector.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <internal/detectors/result.hpp>
+#include <internal/sources/cpuid_source.hpp>
+#include <internal/sources/smbios_base.hpp>
+
+namespace whereami { namespace detectors {
+
+    /**
+     * Hyper-V detector function
+     * @param cpuid_source An instance of a CPUID data source
+     * @param smbios_source An instance of an SMBIOS data source
+     * @return The Hyper-V detection result
+     */
+    result hyperv(const sources::cpuid_base& cpuid_source, sources::smbios_base& smbios_source);
+
+}}  // namespace whereami::detectors

--- a/lib/inc/internal/detectors/kvm_detector.hpp
+++ b/lib/inc/internal/detectors/kvm_detector.hpp
@@ -2,17 +2,17 @@
 
 #include <internal/detectors/result.hpp>
 #include <internal/sources/cpuid_source.hpp>
-#include <internal/sources/dmi_source.hpp>
+#include <internal/sources/smbios_base.hpp>
 
 namespace whereami { namespace detectors {
 
     /**
      * KVM detector function
      * @param cpuid_source A CPUID data source
-     * @param dmi_source A DMI data source
+     * @param smbios_source An SMBIOS data source
      * @return the KVM result
      */
     result kvm(const sources::cpuid_base& cpuid_source,
-               sources::dmi_base& dmi_source);
+               sources::smbios_base& smbios_source);
 
 }}  // namespace whereami::detectors

--- a/lib/inc/internal/detectors/virtualbox_detector.hpp
+++ b/lib/inc/internal/detectors/virtualbox_detector.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
 #include <internal/detectors/result.hpp>
-#include <internal/sources/dmi_source.hpp>
 #include <internal/sources/cpuid_source.hpp>
+#include <internal/sources/smbios_base.hpp>
 
 namespace whereami { namespace detectors {
 
     /**
      * VirtualBox detector function
      * @param cpuid_source An instance of a CPUID data source
-     * @param dmi_source An instance of a DMI data source
+     * @param smbios_source An instance of an SMBIOS data source
      * @return Whether this machine is a VirtualBox guest
      */
     result virtualbox(const sources::cpuid_base& cpuid_source,
-                      const sources::dmi_base& dmi_source);
+                      sources::smbios_base& smbios_source);
 
 }}  // namespace whereami::detectors

--- a/lib/inc/internal/detectors/vmware_detector.hpp
+++ b/lib/inc/internal/detectors/vmware_detector.hpp
@@ -2,18 +2,17 @@
 
 #include <internal/detectors/result.hpp>
 #include <internal/sources/cpuid_source.hpp>
-#include <internal/sources/dmi_source.hpp>
-#include <string>
+#include <internal/sources/smbios_base.hpp>
 
 namespace whereami { namespace detectors {
 
     /**
      * VMware detector function
      * @param cpuid_source An instance of a CPUID data source
-     * @param dmi_source An instance of a DMI data source
+     * @param smbios_source An instance of an SMBIOS data source
      * @return The VMware detection result
      */
     result vmware(const sources::cpuid_base& cpuid_source,
-                  const sources::dmi_base& dmi_source);
+                  sources::smbios_base& smbios_source);
 
 }}  // namespace whereami::detectors

--- a/lib/inc/internal/sources/dmi_source.hpp
+++ b/lib/inc/internal/sources/dmi_source.hpp
@@ -1,128 +1,36 @@
 #pragma once
 
-#include <memory>
-#include <string>
-#include <vector>
+#include "./smbios_base.hpp"
 
 namespace whereami { namespace sources {
 
     /**
-     * Stores information collected via DMI
+     * DMI source for Linux variants
      */
-    struct dmi_data
+    class dmi : public smbios_base
     {
-        /**
-         * The BIOS address
-         * Only available via dmidecode section 0 (requires root)
-         */
-        std::string bios_address;
-        /**
-         * The name of the BIOS vendor
-         * via /sys/class/dmi/id/bios_vendor or dmidecode section 0 vendor
-         */
-        std::string bios_vendor;
-        /**
-         * The board manufacturer
-         * via /sys/class/dmi/id/board_vendor or dmidecode section 2 manufacturer
-         */
-        std::string board_manufacturer;
-        /**
-         * The board product name
-         * via /sys/class/dmi/id/board_name or dmidecode section 2 product name
-         */
-        std::string board_product_name;
-        /**
-         * The system manufacturer (via /sys/class/dmi/id/sys_vendor)
-         * via /sys/class/dmi/id/sys_vendor or dmidecode section 1 manufacturer
-         */
-        std::string manufacturer;
-        /**
-         * The product name
-         * via /sys/class/dmi/id/product_name or dmidecode section 1 product name
-         */
-        std::string product_name;
-        /**
-         * OEM strings
-         * Only available via dmidecode section 11 (requires root)
-         */
-        std::vector<std::string> oem_strings;
-    };
-
-    /**
-     * Base DMI data source
-     */
-    class dmi_base
-    {
-    public:
-        dmi_base() {}
-        virtual ~dmi_base() {}
-        /**
-         * Retrieve the BIOS address
-         * @return The BIOS address
-         */
-        std::string bios_address() const;
-        /**
-         * Retrieve the BIOS vendor
-         * @return The BIOS vendor's name
-         */
-        std::string bios_vendor() const;
-        /**
-         * Retrieve the board manufacturer
-         * @return The board manufacturer's name
-         */
-        std::string board_manufacturer() const;
-        /**
-         * Retrieve the board product name
-         * @return The board product name
-         */
-        std::string board_product_name() const;
-        /**
-         * Retrieve the system manufacturer
-         * @return The system manufacturer
-         */
-        std::string manufacturer() const;
-        /**
-         * Retrieve the product name
-         * @return The product name
-         */
-        std::string product_name() const;
-        /**
-         * Retrieve any OEM strings
-         * @return A vector of OEM strings
-         */
-        std::vector<std::string> oem_strings() const;
     protected:
         /**
-         * Collected data for this machine based on DMI information
+         * Collect data if it hasn't been collected yet, and return a pointer to the DMI data object
+         * @return A pointer to the collected DMI data
          */
-        std::unique_ptr<dmi_data> data_;
-    };
-
-    /**
-     * Default DMI data source
-     */
-    class dmi : public dmi_base
-    {
-     public:
-        dmi();
-        virtual ~dmi() {}
-     protected:
-        /**
-         * /sys path to user-accessible DMI files on *nix systems
-         */
-        constexpr static char const* SYS_PATH = "/sys/class/dmi/id/";
-        /**
-         * Attempt to collect virtualization data using DMI
-         */
-        virtual void collect_data();
+        virtual smbios_data const* data();
         /**
          * Attempt to collect data from files in /sys/class/dmi/id/
+         * @return Whether data was collected
          */
-        virtual void collect_data_from_sys();
+        virtual bool collect_data_from_sys();
         /**
          * Attempt to collect data from dmidecode executable (requires root)
+         * @return Whether data was collected
          */
-        virtual void collect_data_from_dmidecode();
+        virtual bool collect_data_from_dmidecode();
+        /**
+         * Examine a line of dmidecode output for useful information
+         * @param line The contents of the line
+         * @param dmi_type Initial dmi_type value, e.g. -1
+         */
+        void parse_dmidecode_line(std::string& line, int& dmi_type);
         /**
          * Construct a full pathname for files in /sys/class/dmi/id/
          * @param filename The name of the file expected to exist in /sys/class/dmi/id/, e.g. "bios_vendor"
@@ -130,17 +38,15 @@ namespace whereami { namespace sources {
          */
         virtual std::string sys_path(std::string const& filename = "") const;
         /**
-         * Read a single DMI file
+         * Read a single DMI file from SYS_PATH
          * @param path The path to the file
          * @return The contents of the file
          */
         std::string read_file(std::string const& path);
         /**
-         * Examine a line of dmidecode output for useful information
-         * @param line The contents of the line
-         * @param dmi_type Initial dmi_type value, e.g. -1
+         * /sys path to user-accessible DMI files on *nix systems
          */
-        void parse_dmidecode_line(std::string& line, int& dmi_type);
+        constexpr static char const* SYS_PATH {"/sys/class/dmi/id/"};
     };
 
 }}  // namespace whereami::sources

--- a/lib/inc/internal/sources/smbios_base.hpp
+++ b/lib/inc/internal/sources/smbios_base.hpp
@@ -18,32 +18,32 @@ namespace whereami { namespace sources {
         std::string bios_address;
         /**
          * The name of the BIOS vendor
-         * via /sys/class/dmi/id/bios_vendor or dmidecode section 0 vendor
+         * via /sys/class/dmi/id/bios_vendor, dmidecode section 0 vendor, or WMI's bios manufacturer
          */
         std::string bios_vendor;
         /**
          * The board manufacturer
-         * via /sys/class/dmi/id/board_vendor or dmidecode section 2 manufacturer
+         * via /sys/class/dmi/id/board_vendor, dmidecode section 2 manufacturer, or WMI's base board manufacturer
          */
         std::string board_manufacturer;
         /**
          * The board product name
-         * via /sys/class/dmi/id/board_name or dmidecode section 2 product name
+         * via /sys/class/dmi/id/board_name, dmidecode section 2 product name, or WMI's base board product
          */
         std::string board_product_name;
         /**
          * The system manufacturer (via /sys/class/dmi/id/sys_vendor)
-         * via /sys/class/dmi/id/sys_vendor or dmidecode section 1 manufacturer
+         * via /sys/class/dmi/id/sys_vendor, dmidecode section 1 manufacturer, or WMI's computer system manufacturer
          */
         std::string manufacturer;
         /**
          * The product name
-         * via /sys/class/dmi/id/product_name or dmidecode section 1 product name
+         * via /sys/class/dmi/id/product_name, dmidecode section 1 product name, or WMI's computer system product name
          */
         std::string product_name;
         /**
          * OEM strings
-         * Only available via dmidecode section 11 (requires root)
+         * via dmidecode section 11 (requires root), or WMI's computer system OEM string array
          */
         std::vector<std::string> oem_strings;
     };

--- a/lib/inc/internal/sources/smbios_base.hpp
+++ b/lib/inc/internal/sources/smbios_base.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace whereami { namespace sources {
+
+    /**
+     * Stores information collected via SMBIOS
+     */
+    struct smbios_data
+    {
+        /**
+         * The BIOS address
+         * Only available via dmidecode section 0 (requires root)
+         */
+        std::string bios_address;
+        /**
+         * The name of the BIOS vendor
+         * via /sys/class/dmi/id/bios_vendor or dmidecode section 0 vendor
+         */
+        std::string bios_vendor;
+        /**
+         * The board manufacturer
+         * via /sys/class/dmi/id/board_vendor or dmidecode section 2 manufacturer
+         */
+        std::string board_manufacturer;
+        /**
+         * The board product name
+         * via /sys/class/dmi/id/board_name or dmidecode section 2 product name
+         */
+        std::string board_product_name;
+        /**
+         * The system manufacturer (via /sys/class/dmi/id/sys_vendor)
+         * via /sys/class/dmi/id/sys_vendor or dmidecode section 1 manufacturer
+         */
+        std::string manufacturer;
+        /**
+         * The product name
+         * via /sys/class/dmi/id/product_name or dmidecode section 1 product name
+         */
+        std::string product_name;
+        /**
+         * OEM strings
+         * Only available via dmidecode section 11 (requires root)
+         */
+        std::vector<std::string> oem_strings;
+    };
+
+    /**
+     * Base SMBIOS data source
+     */
+    class smbios_base
+    {
+    public:
+        /**
+         * Retrieve the BIOS address
+         * @return The BIOS address
+         */
+        std::string bios_address();
+        /**
+         * Retrieve the BIOS vendor
+         * @return The BIOS vendor's name
+         */
+        std::string bios_vendor();
+        /**
+         * Retrieve the board manufacturer
+         * @return The board manufacturer's name
+         */
+        std::string board_manufacturer();
+        /**
+         * Retrieve the board product name
+         * @return The board product name
+         */
+        std::string board_product_name();
+        /**
+         * Retrieve the system manufacturer
+         * @return The system manufacturer
+         */
+        std::string manufacturer();
+        /**
+         * Retrieve the product name
+         * @return The product name
+         */
+        std::string product_name();
+        /**
+         * Retrieve any OEM strings
+         * @return A vector of OEM strings
+         */
+        std::vector<std::string> oem_strings();
+
+    protected:
+        /**
+         * Collected data for this machine based on SMBIOS information
+         */
+        std::unique_ptr<smbios_data> data_;
+        /**
+         * Collect data if it hasn't been collected yet, and return a pointer to the SMBIOS data object
+         * @return A pointer to the collected SMBIOS data
+         */
+        virtual smbios_data const* data() = 0;
+    };
+
+}}  // namespace whereami::sources

--- a/lib/inc/internal/sources/wmi_source.hpp
+++ b/lib/inc/internal/sources/wmi_source.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "./smbios_base.hpp"
+#include <leatherman/windows/wmi.hpp>
+
+namespace whereami { namespace sources {
+
+    /**
+     * SMBIOS source for Windows, using WMI
+     */
+    class wmi : public smbios_base
+    {
+    public:
+        /**
+         * The Computer System WMI class name
+         */
+        constexpr static char const* class_computersystem = "Win32_ComputerSystem";
+        /**
+         * The Computer System Product WMI class name
+         */
+        constexpr static char const* class_computersystemproduct = "Win32_ComputerSystemProduct";
+        /**
+         * The BIOS WMI class name
+         */
+        constexpr static char const* class_bios = "Win32_Bios";
+        /**
+         * The Base Board WMI class name
+         */
+        constexpr static char const* class_baseboard = "Win32_BaseBoard";
+        /**
+         * The Product WMI property name
+         */
+        constexpr static char const* property_product = "Product";
+        /**
+         * The OEM String Array WMI property name
+         */
+        constexpr static char const* property_oemstringarray = "OEMStringArray";
+        /**
+         * The Name WMI property name
+         */
+        constexpr static char const* property_name = "Name";
+        /**
+         * The Manufactuerer WMI property name
+         */
+        constexpr static char const* property_manufacturer = "Manufacturer";
+
+    protected:
+        /**
+         * Collect data if it hasn't been collected yet, and return a pointer to the SMBIOS data object
+         * @return A pointer to the collected SMBIOS data
+         */
+        virtual smbios_data const* data();
+        /**
+         * Attempt to collect data from WMI
+         * @return Whether data was collected
+         */
+        virtual bool collect_data_from_wmi();
+        /**
+         * WMI connection object
+         */
+        std::unique_ptr<leatherman::windows::wmi> wmi_;
+    };
+
+}}  // namespace whereami::sources

--- a/lib/src/detectors/hyperv_detector.cc
+++ b/lib/src/detectors/hyperv_detector.cc
@@ -1,0 +1,20 @@
+#include <internal/detectors/hyperv_detector.hpp>
+#include <internal/vm.hpp>
+
+using namespace std;
+
+namespace whereami { namespace detectors {
+
+   result hyperv(const sources::cpuid_base& cpuid_source, sources::smbios_base& smbios_source)
+   {
+       result res {vm::hyperv};
+
+       if (cpuid_source.vendor() == "Microsoft Hv" ||
+           smbios_source.manufacturer().find("Microsoft") != string::npos) {
+           res.validate();
+       }
+
+       return res;
+   }
+
+}}  // namespace whereami::detectors

--- a/lib/src/detectors/kvm_detector.cc
+++ b/lib/src/detectors/kvm_detector.cc
@@ -10,22 +10,22 @@ namespace whereami { namespace detectors {
     static const boost::regex parallels_pattern {"^Parallels"};
 
     result kvm(const sources::cpuid_base& cpuid_source,
-               sources::dmi_base& dmi_source)
+               sources::smbios_base& smbios_source)
     {
         result res {vm::kvm};
 
         // dmidecode under KVM typically reports QEMU, but CPUID does report KVM.
         // VirtualBox and Parallels will also report KVM in CPUID, though, so make sure they're not here.
         if (cpuid_source.vendor() == "KVMKVMKVM"
-            && dmi_source.product_name() != "VirtualBox"
-            && !re_search(dmi_source.product_name(), parallels_pattern)) {
+            && smbios_source.product_name() != "VirtualBox"
+            && !re_search(smbios_source.product_name(), parallels_pattern)) {
             res.validate();
 
-            if (dmi_source.bios_vendor() == "Google") {
+            if (smbios_source.bios_vendor() == "Google") {
                 res.set("google", true);
             }
 
-            if (re_search(dmi_source.product_name(), openstack_pattern)) {
+            if (re_search(smbios_source.product_name(), openstack_pattern)) {
                 res.set("openstack", true);
             }
         }

--- a/lib/src/detectors/virtualbox_detector.cc
+++ b/lib/src/detectors/virtualbox_detector.cc
@@ -10,17 +10,17 @@ using namespace leatherman::util;
 namespace whereami { namespace detectors {
 
     result virtualbox(const sources::cpuid_base& cpuid_source,
-                      const sources::dmi_base& dmi_source) {
+                      sources::smbios_base& smbios_source) {
         result res {vm::virtualbox};
 
         if (cpuid_source.vendor() == "VBoxVBoxVBox" ||
-            dmi_source.product_name() == "VirtualBox") {
+            smbios_source.product_name() == "VirtualBox") {
             res.validate();
 
             // Look for VirtualBox version and revision in DMI OEM strings
-            auto oem_strings = dmi_source.oem_strings();
+            auto oem_strings = smbios_source.oem_strings();
 
-            for (auto const& oem_string : dmi_source.oem_strings()) {
+            for (auto const& oem_string : oem_strings) {
                 if (boost::istarts_with(oem_string, "vboxVer_")) {
                     auto version = oem_string.substr(8, string::npos);
                     res.set("version", version);

--- a/lib/src/detectors/vmware_detector.cc
+++ b/lib/src/detectors/vmware_detector.cc
@@ -41,15 +41,15 @@ static string vmware_bios_address_to_version(int address)
 namespace whereami { namespace detectors {
 
     result vmware(const sources::cpuid_base& cpuid_source,
-                  const sources::dmi_base& dmi_source)
+                  sources::smbios_base& smbios_source)
     {
         result res {vm::vmware};
 
-        if (dmi_source.manufacturer() == "VMware, Inc." ||
+        if (smbios_source.manufacturer() == "VMware, Inc." ||
             cpuid_source.vendor() == "VMwareVMware") {
             res.validate();
 
-            auto bios_address = dmi_source.bios_address();
+            auto bios_address = smbios_source.bios_address();
             if (!bios_address.empty()) {
                 auto value = stoi(bios_address, nullptr, 16);
                 res.set("version", vmware_bios_address_to_version(value));

--- a/lib/src/sources/dmi_source.cc
+++ b/lib/src/sources/dmi_source.cc
@@ -1,71 +1,36 @@
 #include <internal/sources/dmi_source.hpp>
-#include <leatherman/util/regex.hpp>
-#include <leatherman/logging/logging.hpp>
-#include <leatherman/file_util/file.hpp>
 #include <leatherman/execution/execution.hpp>
+#include <leatherman/file_util/file.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <leatherman/util/regex.hpp>
+#include <leatherman/util/strings.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
 #include <unordered_map>
 
-using namespace std;
 using namespace boost::filesystem;
+using namespace leatherman::util;
+using namespace std;
+
 namespace bs = boost::system;
 namespace lth_file = leatherman::file_util;
-using namespace leatherman::util;
+namespace lth_exe = leatherman::execution;
 
 namespace whereami { namespace sources {
 
-    std::string dmi_base::bios_address() const
+    smbios_data const* dmi::data()
     {
-        return data_ ? data_->bios_address : "";
-    }
-
-    std::string dmi_base::bios_vendor() const
-    {
-        return data_ ? data_->bios_vendor : "";
-    }
-
-    std::string dmi_base::board_manufacturer() const
-    {
-        return data_ ? data_->board_manufacturer : "";
-    }
-
-    std::string dmi_base::board_product_name() const
-    {
-        return data_ ? data_->board_product_name : "";
-    }
-
-    std::string dmi_base::product_name() const
-    {
-        return data_ ? data_->product_name : "";
-    }
-
-    std::string dmi_base::manufacturer() const
-    {
-        return data_ ? data_->manufacturer : "";
-    }
-
-    std::vector<std::string> dmi_base::oem_strings() const
-    {
-        if (data_) {
-            return data_->oem_strings;
-        }
-        return {};
-    }
-
-    dmi::dmi()
-    {
-        collect_data();
-    }
-
-    void dmi::collect_data()
-    {
-        // Attempt to use dmidecode first, because it yields extra metadata (requires root)
-        collect_data_from_dmidecode();
         if (!data_) {
-            // Otherwise, collect most of dmidecode's data from user-accessible files in /sys/
-            collect_data_from_sys();
+            // Attempt to use dmidecode first, because it yields extra metadata (requires root)
+            if (!collect_data_from_dmidecode()) {
+                // Otherwise, collect most of dmidecode's data from user-accessible files in /sys/
+                if (!collect_data_from_sys()) {
+                    // If both methods failed, the result should be empty
+                    data_.reset(new smbios_data);
+                }
+            }
         }
+        return data_.get();
     }
 
     string dmi::sys_path(string const& filename) const
@@ -73,42 +38,53 @@ namespace whereami { namespace sources {
         return SYS_PATH + filename;
     }
 
-    void dmi::collect_data_from_sys()
+    bool dmi::collect_data_from_sys()
     {
-        // Check that /sys/class/dmi exists
-        bs::error_code ec;
-        if (is_directory(sys_path(), ec)) {
-            if (!data_) {
-                data_.reset(new dmi_data);
-            }
-            data_->bios_vendor = read_file(sys_path("bios_vendor"));
-            data_->board_manufacturer = read_file(sys_path("board_vendor"));
-            data_->board_product_name = read_file(sys_path("board_name"));
-            data_->manufacturer = read_file(sys_path("sys_vendor"));
-            data_->product_name = read_file(sys_path("product_name"));
-        } else {
-            LOG_DEBUG(sys_path() + " cannot be accessed.");
+        if (!is_directory(sys_path())) {
+            LOG_DEBUG(sys_path() + " not found.");
+            return false;
         }
+
+        if (!data_) {
+            data_.reset(new smbios_data);
+        }
+
+        data_->bios_vendor = read_file(sys_path("bios_vendor"));
+        data_->board_manufacturer = read_file(sys_path("board_vendor"));
+        data_->board_product_name = read_file(sys_path("board_name"));
+        data_->manufacturer = read_file(sys_path("sys_vendor"));
+        data_->product_name = read_file(sys_path("product_name"));
+
+        return true;
     }
 
-    void dmi::collect_data_from_dmidecode()
+    bool dmi::collect_data_from_dmidecode()
     {
         LOG_DEBUG("Using dmidecode to query DMI information.");
 
-        string dmidecode = leatherman::execution::which("dmidecode");
+        string exec_path = lth_exe::which("dmidecode");
 
-        if (dmidecode.empty()) {
+        if (exec_path.empty()) {
             LOG_DEBUG("dmidecode executable not found");
-        } else {
-            int dmi_type {-1};
-            leatherman::execution::each_line(dmidecode, [&](string& line) {
-                parse_dmidecode_line(line, dmi_type);
-                return true;
-            });
+            return false;
         }
+
+        auto res = lth_exe::execute(exec_path);
+
+        if (res.exit_code != 0) {
+            LOG_DEBUG("Error while running dmidecode ({1})", res.exit_code);
+            return false;
+        }
+
+        int dmi_type {-1};
+        each_line(res.output, [&](string& line) {
+            parse_dmidecode_line(line, dmi_type);
+            return true;
+        });
+
+        return data_.get() == nullptr;
     }
 
-    // Read a single file in the DMI directory
     string dmi::read_file(string const& path)
     {
         bs::error_code ec;
@@ -137,23 +113,23 @@ namespace whereami { namespace sources {
 
     void dmi::parse_dmidecode_line(string& line, int& dmi_type)
     {
-        static const boost::regex dmi_section_pattern {"^Handle 0x.{4}, DMI type (\\d{1,3})"};
+        static const boost::regex dmi_section_pattern{"^Handle 0x.{4}, DMI type (\\d{1,3})"};
 
-        // Stores the relevant DMI sections
+        // Stores the relevant DMI section titles
         static const unordered_map<int, vector<string>> sections {
-            { 0, {  // BIOS
+            {0, {  // BIOS
                 "vendor:",
                 "address:",
             }},
-            { 1, {  // System
+            {1, {  // System
                 "manufacturer:",
                 "product name:",
             }},
-            { 2, {  // Base Board
+            {2, {  // Base Board
                "manufacturer:",
                "product name:",
             }},
-            { 11, {  // OEM Strings
+            {11, {  // OEM Strings
                 "string 1:",
                 "string 2:",
                 "string 3:",
@@ -191,7 +167,7 @@ namespace whereami { namespace sources {
         auto index = it - headers.begin();
 
         if (!data_) {
-            data_.reset(new dmi_data);
+            data_.reset(new smbios_data);
         }
 
         // Assign to the appropriate member
@@ -199,8 +175,7 @@ namespace whereami { namespace sources {
             case 0: {  // BIOS information
                 if (index == 0) {
                     data_->bios_vendor = move(value);
-                }
-                if (index == 1) {
+                } else if (index == 1) {
                     data_->bios_address = move(value);
                 }
                 break;

--- a/lib/src/sources/dmi_source.cc
+++ b/lib/src/sources/dmi_source.cc
@@ -209,4 +209,4 @@ namespace whereami { namespace sources {
         }
     }
 
-}};  // namespace whereami::sources
+}}  // namespace whereami::sources

--- a/lib/src/sources/smbios_base.cc
+++ b/lib/src/sources/smbios_base.cc
@@ -1,0 +1,40 @@
+#include <internal/sources/smbios_base.hpp>
+
+namespace whereami { namespace sources {
+
+    std::string smbios_base::bios_address()
+    {
+        return data()->bios_address;
+    }
+
+    std::string smbios_base::bios_vendor()
+    {
+        return data()->bios_vendor;
+    }
+
+    std::string smbios_base::board_manufacturer()
+    {
+        return data()->board_manufacturer;
+    }
+
+    std::string smbios_base::board_product_name()
+    {
+        return data()->board_product_name;
+    }
+
+    std::string smbios_base::product_name()
+    {
+        return data()->product_name;
+    }
+
+    std::string smbios_base::manufacturer()
+    {
+        return data()->manufacturer;
+    }
+
+    std::vector<std::string> smbios_base::oem_strings()
+    {
+        return data()->oem_strings;
+    }
+
+}}  // namespace whereami::sources

--- a/lib/src/sources/wmi_source.cc
+++ b/lib/src/sources/wmi_source.cc
@@ -1,0 +1,52 @@
+#include <internal/sources/wmi_source.hpp>
+
+namespace lth_windows = leatherman::windows;
+
+namespace whereami { namespace sources {
+
+    smbios_data const* wmi::data()
+    {
+        if (!data_) {
+            if (!wmi_) {
+                wmi_.reset(new lth_windows::wmi);
+            }
+            collect_data_from_wmi();
+        }
+        return data_.get();
+    }
+
+    bool wmi::collect_data_from_wmi()
+    {
+        auto computersystem_values = wmi_->query(class_computersystem, {
+                property_manufacturer,
+                property_oemstringarray});
+        auto computersystemproduct_values = wmi_->query(class_computersystemproduct, {
+                property_name});
+        auto baseboard_values = wmi_->query(class_baseboard, {
+                property_manufacturer,
+                property_product});
+        auto bios_values = wmi_->query(class_bios, {
+                property_manufacturer});
+
+        if (computersystem_values.empty() && computersystemproduct_values.empty() && baseboard_values.empty()) {
+            return false;
+        }
+
+        data_.reset(new smbios_data);
+
+        data_->bios_vendor = lth_windows::wmi::get(bios_values, property_manufacturer);
+        data_->board_manufacturer = lth_windows::wmi::get(baseboard_values, property_manufacturer);
+        data_->board_product_name = lth_windows::wmi::get(baseboard_values, property_product);
+        data_->manufacturer = lth_windows::wmi::get(computersystem_values, property_manufacturer);
+        data_->product_name = lth_windows::wmi::get(computersystemproduct_values, property_name);
+
+        for (auto& value : computersystem_values.at(0)) {
+            if (value.first == property_oemstringarray) {
+                data_->oem_strings.emplace_back(value.second);
+            }
+        }
+
+        return true;
+    }
+
+}};  // namespace whereami::sources

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -1,7 +1,6 @@
 #include <whereami/whereami.hpp>
 #include <whereami/version.h>
 #include <internal/vm.hpp>
-#include <internal/sources/dmi_source.hpp>
 #include <internal/sources/cgroup_source.hpp>
 #include <internal/sources/cpuid_source.hpp>
 #include <internal/detectors/docker_detector.hpp>
@@ -11,6 +10,12 @@
 #include <internal/detectors/virtualbox_detector.hpp>
 #include <internal/detectors/vmware_detector.hpp>
 #include <leatherman/logging/logging.hpp>
+
+#if defined(_WIN32)
+#include <internal/sources/wmi_source.hpp>
+#else
+#include <internal/sources/dmi_source.hpp>
+#endif
 
 using namespace std;
 using namespace whereami;
@@ -27,7 +32,13 @@ namespace whereami {
     vector<result> hypervisors()
     {
         vector<result> results;
+
+#if defined(_WIN32)
+        sources::wmi smbios_source;
+#else
         sources::dmi smbios_source;
+#endif
+
         sources::cpuid cpuid_source;
         sources::cgroup cgroup_source;
 

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -4,6 +4,7 @@
 #include <internal/sources/cgroup_source.hpp>
 #include <internal/sources/cpuid_source.hpp>
 #include <internal/detectors/docker_detector.hpp>
+#include <internal/detectors/hyperv_detector.hpp>
 #include <internal/detectors/kvm_detector.hpp>
 #include <internal/detectors/lxc_detector.hpp>
 #include <internal/detectors/openvz_detector.hpp>
@@ -76,6 +77,12 @@ namespace whereami {
 
         if (kvm_result.valid()) {
             results.emplace_back(kvm_result);
+        }
+
+        auto hyperv_result = detectors::hyperv(cpuid_source, smbios_source);
+
+        if (hyperv_result.valid()) {
+            results.emplace_back(hyperv_result);
         }
 
         return results;

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -27,17 +27,17 @@ namespace whereami {
     vector<result> hypervisors()
     {
         vector<result> results;
-        sources::dmi dmi_source;
+        sources::dmi smbios_source;
         sources::cpuid cpuid_source;
         sources::cgroup cgroup_source;
 
-        auto virtualbox_result = detectors::virtualbox(cpuid_source, dmi_source);
+        auto virtualbox_result = detectors::virtualbox(cpuid_source, smbios_source);
 
         if (virtualbox_result.valid()) {
             results.emplace_back(virtualbox_result);
         }
 
-        auto vmware_result = detectors::vmware(cpuid_source, dmi_source);
+        auto vmware_result = detectors::vmware(cpuid_source, smbios_source);
 
         if (vmware_result.valid()) {
             results.emplace_back(vmware_result);
@@ -61,7 +61,7 @@ namespace whereami {
             results.emplace_back(openvz_result);
         }
 
-        auto kvm_result = detectors::kvm(cpuid_source, dmi_source);
+        auto kvm_result = detectors::kvm(cpuid_source, smbios_source);
 
         if (kvm_result.valid()) {
             results.emplace_back(kvm_result);

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_CASES
     "detectors/openvz_detector.cc"
     "detectors/result.cc"
     "detectors/docker_detector.cc"
+    "detectors/hyperv_detector.cc"
     "detectors/kvm_detector.cc"
     "detectors/lxc_detector.cc"
     "detectors/nspawn_detector.cc"

--- a/lib/tests/detectors/hyperv_detector.cc
+++ b/lib/tests/detectors/hyperv_detector.cc
@@ -1,0 +1,49 @@
+#include <catch.hpp>
+#include <internal/detectors/hyperv_detector.hpp>
+#include "../fixtures/cpuid_fixtures.hpp"
+#include "../fixtures/dmi_fixtures.hpp"
+
+using namespace std;
+using namespace whereami::detectors;
+using namespace whereami::sources;
+using namespace whereami::testing::dmi;
+using namespace whereami::testing::cpuid;
+
+SCENARIO("Using the Hyper-V detector") {
+    cpuid_fixture_values cpuid_empty({
+        {VENDOR_LEAF,        register_fixtures::VENDOR_NONE},
+        {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT}
+    });
+    cpuid_fixture_values cpuid_source({
+        {VENDOR_LEAF,        register_fixtures::VENDOR_Microsoft_Hv},
+        {HYPERVISOR_PRESENT, register_fixtures::HYPERVISOR_PRESENT},
+    });
+
+    dmi_fixture_values dmi_source({
+        "",
+        "Microsoft Corporation",
+        "Microsoft Corporation",
+        "Virtual Machine",
+        "Microsoft Corporation",
+        "Virtual Machine", {
+            "[MS_VM_CERT/SHA1/9b80ca0d5dd061ec9da4e494f4c3fd1196270c22]",
+            "00000000000000000000000000000000",
+            "To be filled by OEM"},
+    });
+
+    WHEN("running on a Hyper-V guest and relying on CPUID") {
+        auto res = hyperv(cpuid_source, dmi_source);
+
+        THEN("Hyper-V is detected") {
+            REQUIRE(res.valid());
+        }
+    }
+
+    WHEN("running on a Hyper-V guest and relying on DMI") {
+        auto res = hyperv(cpuid_empty, dmi_source);
+
+        THEN("Hyper-V is detected") {
+            REQUIRE(res.valid());
+        }
+    }
+}

--- a/lib/tests/fixtures/cpuid_fixtures.hpp
+++ b/lib/tests/fixtures/cpuid_fixtures.hpp
@@ -33,6 +33,7 @@ namespace whereami { namespace testing { namespace cpuid {
         static const sources::cpuid_registers VENDOR_NONE{0, 0, 0, 0};
         static const sources::cpuid_registers VENDOR_AUTHENTICAMD{13, 1752462657, 1145913699, 1769238117};
         static const sources::cpuid_registers VENDOR_KVMKVMKVM{0, 1263359563, 1447775574, 77};
+        static const sources::cpuid_registers VENDOR_Microsoft_Hv{1073741830, 1919117645, 1718580079, 1984438388};
         static const sources::cpuid_registers VENDOR_VBoxVBoxVBox{0, 2020557398, 2020557398, 2020557398};
         static const sources::cpuid_registers VENDOR_VMwareVMware{1073741840, 1635208534, 1297507698, 1701994871};
     }

--- a/lib/tests/fixtures/dmi_fixtures.cc
+++ b/lib/tests/fixtures/dmi_fixtures.cc
@@ -6,32 +6,40 @@ using namespace std;
 
 namespace whereami { namespace testing { namespace dmi {
 
-    dmi_fixture::dmi_fixture(std::string const& dmidecode_path, std::string const& sys_path)
-        : dmidecode_fixture_path_(dmidecode_path), sys_fixture_path_(sys_path)
-    {
-        data_.reset(nullptr);
-        collect_data();
-    }
-
-    std::string dmi_fixture::sys_path(std::string const& filename = "") const
+    std::string dmi_fixture::sys_path(std::string const& filename) const
     {
         return fixture_root + sys_fixture_path_ + filename;
     }
 
-    void dmi_fixture::collect_data_from_dmidecode()
+    bool dmi_fixture::collect_data_from_dmidecode()
     {
-        int dmi_type = -1;
         std::string dmidecode_output;
-        if (!load_fixture(dmidecode_fixture_path_, dmidecode_output)) return;
+
+        if (!load_fixture(dmidecode_fixture_path_, dmidecode_output)) {
+            return false;
+        }
+
+        int dmi_type {-1};
+
         leatherman::util::each_line(dmidecode_output, [&](string& line) {
             parse_dmidecode_line(line, dmi_type);
             return true;
         });
+
+        return data_.get() != nullptr;
     }
 
-    dmi_fixture_values::dmi_fixture_values(sources::dmi_data&& data)
+    dmi_fixture_values::dmi_fixture_values(sources::smbios_data&& data)
     {
-        data_.reset(new dmi_data(move(data)));
+        data_.reset(new smbios_data(move(data)));
+    }
+
+    smbios_data const* dmi_fixture_empty::data()
+    {
+        if (!data_) {
+            data_.reset(new smbios_data);
+        }
+        return data_.get();
     }
 
 }}}  // namespace whereami::testing::dmi

--- a/lib/tests/fixtures/dmi_fixtures.hpp
+++ b/lib/tests/fixtures/dmi_fixtures.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "../fixtures.hpp"
 #include <internal/sources/dmi_source.hpp>
 #include <leatherman/util/strings.hpp>
@@ -6,36 +8,40 @@
 
 namespace whereami { namespace testing { namespace dmi {
 
-    using dmi_fixture_empty = sources::dmi_base;
-
-    /**
-     * Common fixture paths within the fixture base path
-     */
-    namespace dmi_fixtures {
-        static const std::string SYS_NONE = "<none>";
-        static const std::string SYS_VIRTUALBOX = "filesystem/dmi_source/virtualbox_root/sys/class/dmi/id/";
-        static const std::string DMIDECODE_NONE = "output/dmidecode/none.txt";
-        static const std::string DMIDECODE_VIRTUALBOX = "output/dmidecode/virtualbox.txt";
-    }
-
     /**
      * DMI data source relying on fixtures for dmidecode output and /sys/class/dmi/id/ files
      */
-    class dmi_fixture : public sources::dmi {
+    class dmi_fixture : public sources::dmi
+    {
     public:
-        dmi_fixture(std::string const& dmidecode_path = dmi_fixtures::DMIDECODE_NONE,
-                    std::string const& sys_path       = dmi_fixtures::SYS_NONE);
+        /**
+         * Common fixture paths within the fixture base path
+         */
+        constexpr static char const* SYS_NONE  {"<none>"};
+        constexpr static char const* SYS_VIRTUALBOX {"filesystem/dmi_source/virtualbox_root/sys/class/dmi/id/"};
+        constexpr static char const* DMIDECODE_NONE {"output/dmidecode/none.txt"};
+        constexpr static char const* DMIDECODE_VIRTUALBOX {"output/dmidecode/virtualbox.txt"};
+        /**
+         * Constructor specifying paths to fixture for /sys files and dmi output
+         * @param dmidecode_path
+         * @param sys_path
+         */
+        explicit dmi_fixture(std::string dmidecode_path = DMIDECODE_NONE,
+                             std::string sys_path       = SYS_NONE)
+            : dmidecode_fixture_path_(std::move(dmidecode_path)),
+              sys_fixture_path_(std::move(sys_path)) { }
+
     protected:
         /**
          * Read /sys/ data from a fixture base path (instead of from /sys/)
          * @return
          */
-        std::string sys_path(std::string const&) const override;
+        std::string sys_path(std::string const& filename = "") const override;
         /**
-         * Read dmidecode data from a fixture file (instead of the dmidecode executable output)
+         * Read dmidecode output data from a fixture file
          * @return
          */
-        void collect_data_from_dmidecode() override;
+        bool collect_data_from_dmidecode() override;
         /**
          * The dmidecode fixture file path
          */
@@ -49,10 +55,19 @@ namespace whereami { namespace testing { namespace dmi {
     /**
      * DMI data source relying on explicitly specified values
      */
-    class dmi_fixture_values : public sources::dmi_base {
+    class dmi_fixture_values : public sources::dmi
+    {
     public:
-        dmi_fixture_values(sources::dmi_data&& data);
-        ~dmi_fixture_values() {}
+        explicit dmi_fixture_values(sources::smbios_data&& data);
+    };
+
+    /**
+     * DMI data source with no information
+     */
+    class dmi_fixture_empty : public sources::dmi
+    {
+    protected:
+        sources::smbios_data const* data() override;
     };
 
 }}}  // namespace whereami::testing::dmi

--- a/lib/tests/sources/dmi_source.cc
+++ b/lib/tests/sources/dmi_source.cc
@@ -1,7 +1,6 @@
 #include <catch.hpp>
 #include <internal/sources/dmi_source.hpp>
 #include <leatherman/file_util/file.hpp>
-#include <leatherman/util/strings.hpp>
 #include <boost/filesystem.hpp>
 #include "../fixtures/dmi_fixtures.hpp"
 
@@ -14,8 +13,8 @@ using namespace whereami::testing::dmi;
 SCENARIO("Using the DMI data source") {
     WHEN("DMI data is read from /sys/class/dmi/id/") {
         dmi_fixture dmi_source {
-            dmi_fixtures::DMIDECODE_NONE,
-            dmi_fixtures::SYS_VIRTUALBOX
+            dmi_fixture::DMIDECODE_NONE,
+            dmi_fixture::SYS_VIRTUALBOX
         };
         THEN("accessible string fields are populated via /sys/") {
             REQUIRE(dmi_source.bios_vendor() == "innotek GmbH");
@@ -33,8 +32,8 @@ SCENARIO("Using the DMI data source") {
     WHEN("DMI data is read from dmidecode") {
         AND_WHEN("output exists but there is no data available") {
             dmi_fixture dmi_source {
-                dmi_fixtures::DMIDECODE_NONE,
-                dmi_fixtures::SYS_NONE
+                dmi_fixture::DMIDECODE_NONE,
+                dmi_fixture::SYS_NONE
             };
             THEN("nothing is found") {
                 REQUIRE(dmi_source.bios_address().empty());
@@ -49,8 +48,8 @@ SCENARIO("Using the DMI data source") {
 
         AND_WHEN("output exists and data is available") {
             dmi_fixture dmi_source {
-                dmi_fixtures::DMIDECODE_VIRTUALBOX,
-                dmi_fixtures::SYS_NONE
+                dmi_fixture::DMIDECODE_VIRTUALBOX,
+                dmi_fixture::SYS_NONE
             };
             THEN("all fields are populated via dmidecode") {
                 REQUIRE(dmi_source.bios_address() == "0xE0000");


### PR DESCRIPTION
Three commits:

Previously, the DMI data source collected data in its constructor, so even when DMI wouldn't have been used anyway, it would still try to collect on instantiation. The first commit here does the following:
- changes the DMI source so that it only collects data once one of the data values is accessed, and
- renames `dmi_base` to `smbios_base`, since DMI isn't an accurate name on windows or solaris

The second commit adds an implementation of the `smbios_base` using WMI. This worked fine in manual tests, but there are no automated tests here (yet?).

The third commit adds the Hyper-V detector. Checking the CPUID result for `Microsoft Hv` seems to be a reliable way to do this, but SMBIOS is checked as a fallback.

(Also, it occurred to me that this will have a few test fixture conflicts with the xen PR I have open now (#15) - I'll fix/rebase whichever as necessary)
