### PR TITLE
Add system_profiler data source and improve MacOS support

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -33,7 +33,8 @@ set(PROJECT_SOURCES
     "src/sources/cgroup_source.cc"
     "src/sources/cpuid_source.cc"
     "src/sources/dmi_source.cc"
-    "src/sources/smbios_base.cc")
+    "src/sources/smbios_base.cc"
+    "src/sources/system_profiler_source.cc")
 
 if(WIN32)
     set(PROJECT_SOURCES ${PROJECT_SOURCES} "src/sources/wmi_source.cc")

--- a/lib/inc/internal/detectors/virtualbox_detector.hpp
+++ b/lib/inc/internal/detectors/virtualbox_detector.hpp
@@ -3,6 +3,7 @@
 #include <internal/detectors/result.hpp>
 #include <internal/sources/cpuid_source.hpp>
 #include <internal/sources/smbios_base.hpp>
+#include <internal/sources/system_profiler_source.hpp>
 
 namespace whereami { namespace detectors {
 
@@ -10,9 +11,11 @@ namespace whereami { namespace detectors {
      * VirtualBox detector function
      * @param cpuid_source An instance of a CPUID data source
      * @param smbios_source An instance of an SMBIOS data source
+     * @param system_profiler_source An instance of a system_profiler data source
      * @return Whether this machine is a VirtualBox guest
      */
     result virtualbox(const sources::cpuid_base& cpuid_source,
-                      sources::smbios_base& smbios_source);
+                      sources::smbios_base& smbios_source,
+                      sources::system_profiler& system_profiler_source);
 
 }}  // namespace whereami::detectors

--- a/lib/inc/internal/detectors/vmware_detector.hpp
+++ b/lib/inc/internal/detectors/vmware_detector.hpp
@@ -3,6 +3,7 @@
 #include <internal/detectors/result.hpp>
 #include <internal/sources/cpuid_source.hpp>
 #include <internal/sources/smbios_base.hpp>
+#include <internal/sources/system_profiler_source.hpp>
 
 namespace whereami { namespace detectors {
 
@@ -10,9 +11,11 @@ namespace whereami { namespace detectors {
      * VMware detector function
      * @param cpuid_source An instance of a CPUID data source
      * @param smbios_source An instance of an SMBIOS data source
+     * @param system_profiler_source An instance of a system_profiler data source
      * @return The VMware detection result
      */
     result vmware(const sources::cpuid_base& cpuid_source,
-                  sources::smbios_base& smbios_source);
+                  sources::smbios_base& smbios_source,
+                  sources::system_profiler& system_profiler_source);
 
 }}  // namespace whereami::detectors

--- a/lib/inc/internal/sources/system_profiler_source.hpp
+++ b/lib/inc/internal/sources/system_profiler_source.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace whereami { namespace sources {
+
+    /**
+     * Stores information collected from the system profiler on MacOS
+     */
+    struct system_profiler_data
+    {
+        /**
+         * The Boot ROM Version, via SPHardwareDataType
+         */
+        std::string boot_rom_version;
+
+        /**
+         * The Model Identifier, via SPHardwareDataType
+         */
+        std::string model_identifier;
+
+        /**
+         * The serial number (system), via SPHardwareDataType
+         */
+        std::string system_serial_number;
+    };
+
+    /**
+     * System Profiler data source for MacOS
+     */
+    class system_profiler
+    {
+    public:
+        /**
+         * Retrieve the hardware model identifier
+         * @return The model identifier string
+         */
+        std::string model_identifier();
+
+        /**
+         * Retrieve the boot ROM version string
+         * @return the boot ROM version string
+         */
+        std::string boot_rom_version();
+
+        /**
+         * Retrieve the system serial number string
+         * @return the system serial number string
+         */
+        std::string system_serial_number();
+
+    protected:
+        /**
+         * Collected system profiler data values
+         */
+        std::unique_ptr<system_profiler_data> data_;
+
+        /**
+         * Hardware data type argument for the system_profiler executable
+         */
+        constexpr static char const* hardware_data_type_ = "SPHardwareDataType";
+
+        /**
+         * Collect data from system_profiler
+         */
+        virtual void collect_data();
+
+        /**
+         * Collect data if it hasn't been collected yet, and return a pointer to the data object
+         * @return A pointer to a populated `system_profiler_data` instance
+         */
+        virtual system_profiler_data const* data();
+
+        /**
+         * Call the system profile executable and return the output
+         * @param args Arguments to pass to system_profiler
+         * @return The output of system_profiler given the supplied arguments
+         */
+        virtual std::string read_system_profiler_output(const std::vector<std::string>& args);
+    };
+
+}}  // namespace whereami::sources

--- a/lib/src/detectors/virtualbox_detector.cc
+++ b/lib/src/detectors/virtualbox_detector.cc
@@ -10,11 +10,13 @@ using namespace leatherman::util;
 namespace whereami { namespace detectors {
 
     result virtualbox(const sources::cpuid_base& cpuid_source,
-                      sources::smbios_base& smbios_source) {
+                      sources::smbios_base& smbios_source,
+                      sources::system_profiler& system_profiler_source) {
         result res {vm::virtualbox};
 
         if (cpuid_source.vendor() == "VBoxVBoxVBox" ||
-            smbios_source.product_name() == "VirtualBox") {
+            smbios_source.product_name() == "VirtualBox" ||
+            system_profiler_source.boot_rom_version() == "VirtualBox") {
             res.validate();
 
             // Look for VirtualBox version and revision in DMI OEM strings

--- a/lib/src/sources/system_profiler_source.cc
+++ b/lib/src/sources/system_profiler_source.cc
@@ -1,0 +1,83 @@
+#include <internal/sources/system_profiler_source.hpp>
+#include <leatherman/execution/execution.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <leatherman/util/regex.hpp>
+#include <leatherman/util/strings.hpp>
+#include <boost/algorithm/string.hpp>
+
+using namespace std;
+using namespace leatherman::util;
+
+namespace lth_exe = leatherman::execution;
+
+namespace whereami { namespace sources {
+
+    std::string system_profiler::boot_rom_version()
+    {
+        return data()->boot_rom_version;
+    }
+
+    std::string system_profiler::model_identifier()
+    {
+        return data()->model_identifier;
+    }
+
+    std::string system_profiler::system_serial_number()
+    {
+        return data()->system_serial_number;
+    }
+
+    system_profiler_data const* system_profiler::data()
+    {
+        if (!data_) {
+            collect_data();
+        }
+
+        return data_.get();
+    }
+
+    std::string system_profiler::read_system_profiler_output(const std::vector<std::string>& args)
+    {
+        string exec_path = lth_exe::which("system_profiler");
+
+        if (exec_path.empty()) {
+            return {};
+        }
+
+        auto res = lth_exe::execute(exec_path, args);
+
+        if (res.exit_code != 0) {
+            return {};
+        }
+
+        return res.output;
+    }
+
+    void system_profiler::collect_data()
+    {
+        if (!data_) {
+            data_.reset(new system_profiler_data);
+        }
+
+        auto output = read_system_profiler_output({hardware_data_type_});
+
+        static const boost::regex boot_rom_version_pattern {"^Boot ROM Version: (.+)$"};
+        static const boost::regex model_identifier_pattern {"^Model Identifier: (.+)$"};
+        static const boost::regex system_serial_number_pattern {"^Serial Number \\(system\\): (.+)$"};
+
+        string value;
+        each_line(output, [&](string& line) {
+            boost::trim(line);
+
+            if (re_search(line, boot_rom_version_pattern, &value)) {
+                data_->boot_rom_version = move(value);
+            } else if (re_search(line, model_identifier_pattern, &value)) {
+                data_->model_identifier = move(value);
+            } else if (re_search(line, system_serial_number_pattern, &value)) {
+                data_->system_serial_number = move(value);
+            }
+            return true;
+        });
+    }
+
+}}  // namespace whereami::sources

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -45,7 +45,7 @@ namespace whereami {
         sources::cgroup cgroup_source;
         sources::system_profiler system_profiler_source;
 
-        auto virtualbox_result = detectors::virtualbox(cpuid_source, smbios_source);
+        auto virtualbox_result = detectors::virtualbox(cpuid_source, smbios_source, system_profiler_source);
 
         if (virtualbox_result.valid()) {
             results.emplace_back(virtualbox_result);

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -16,6 +16,7 @@
 #include <internal/sources/wmi_source.hpp>
 #else
 #include <internal/sources/dmi_source.hpp>
+#include <internal/sources/system_profiler_source.hpp>
 #endif
 
 using namespace std;
@@ -42,6 +43,7 @@ namespace whereami {
 
         sources::cpuid cpuid_source;
         sources::cgroup cgroup_source;
+        sources::system_profiler system_profiler_source;
 
         auto virtualbox_result = detectors::virtualbox(cpuid_source, smbios_source);
 
@@ -49,7 +51,7 @@ namespace whereami {
             results.emplace_back(virtualbox_result);
         }
 
-        auto vmware_result = detectors::vmware(cpuid_source, smbios_source);
+        auto vmware_result = detectors::vmware(cpuid_source, smbios_source, system_profiler_source);
 
         if (vmware_result.valid()) {
             results.emplace_back(vmware_result);

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -19,7 +19,8 @@ set(TEST_CASES
     "fixtures/dmi_fixtures.cc"
     "sources/cgroup_source.cc"
     "sources/cpuid_source.cc"
-    "sources/dmi_source.cc")
+    "sources/dmi_source.cc"
+    "sources/system_profiler_source.cc")
 
 add_executable(lib${PROJECT_NAME}_test $<TARGET_OBJECTS:libprojectsrc> ${TEST_CASES} main.cc)
 target_link_libraries(lib${PROJECT_NAME}_test

--- a/lib/tests/detectors/virtualbox_detector.cc
+++ b/lib/tests/detectors/virtualbox_detector.cc
@@ -3,12 +3,14 @@
 #include <internal/detectors/virtualbox_detector.hpp>
 #include "../fixtures/dmi_fixtures.hpp"
 #include "../fixtures/cpuid_fixtures.hpp"
+#include "../fixtures/system_profiler_fixtures.hpp"
 
 using namespace std;
 using namespace whereami::detectors;
 using namespace whereami::sources;
 using namespace whereami::testing::dmi;
 using namespace whereami::testing::cpuid;
+using namespace whereami::testing::system_profiler;
 
 SCENARIO("Using the VirtualBox detector") {
     WHEN("running on a Linux VirtualBox guest with root") {
@@ -29,7 +31,8 @@ SCENARIO("Using the VirtualBox detector") {
                 "vboxVer_5.1.22",
                 "vboxRev_115126",
             }});
-        auto res = virtualbox(cpuid_source, dmi_source);
+        system_profiler_fixture system_profiler_source({});
+        auto res = virtualbox(cpuid_source, dmi_source, system_profiler_source);
         THEN("the result should be valid") {
             REQUIRE(res.valid());
         }
@@ -54,7 +57,8 @@ SCENARIO("Using the VirtualBox detector") {
             "innotek GmbH",
             "VirtualBox",
             {}});
-        auto const& res = virtualbox(cpuid_source, dmi_source);
+        system_profiler_fixture system_profiler_source({});
+        auto const& res = virtualbox(cpuid_source, dmi_source, system_profiler_source);
         THEN("the result should be valid") {
             REQUIRE(res.valid());
         }
@@ -72,8 +76,24 @@ SCENARIO("Using the VirtualBox detector") {
                 {0, register_fixtures::HYPERVISOR_PRESENT}}}};
         cpuid_fixture cpuid_source {values};
         dmi_fixture_empty dmi_source;
+        system_profiler_fixture system_profiler_source({});
         THEN("the result should be valid") {
-            auto res = virtualbox(cpuid_source, dmi_source);
+            auto res = virtualbox(cpuid_source, dmi_source, system_profiler_source);
+            REQUIRE(res.valid());
+        }
+    }
+
+    WHEN("running on a MacOS VirtualBox guest") {
+        leaf_register_map values {
+            {VENDOR_LEAF, {
+                {0, register_fixtures::VENDOR_NONE}}},
+            {HYPERVISOR_PRESENT_LEAF, {
+                {0, register_fixtures::HYPERVISOR_ABSENT}}}};
+        cpuid_fixture cpuid_source {values};
+        dmi_fixture_empty dmi_source;
+        system_profiler_fixture system_profiler_source(system_profiler_fixture::SYSTEM_PROFILER_VIRTUALBOX);
+        THEN("the reuslt should be valid") {
+            auto res = virtualbox(cpuid_source, dmi_source, system_profiler_source);
             REQUIRE(res.valid());
         }
     }
@@ -93,8 +113,9 @@ SCENARIO("Using the VirtualBox detector") {
             "Other",
             "Other",
             {}});
+        system_profiler_fixture system_profiler_source({});
         THEN("the result should not be valid") {
-            auto res = virtualbox(cpuid_source, dmi_source);
+            auto res = virtualbox(cpuid_source, dmi_source, system_profiler_source);
             REQUIRE_FALSE(res.valid());
         }
     }

--- a/lib/tests/fixtures/output/system_profiler/physical.txt
+++ b/lib/tests/fixtures/output/system_profiler/physical.txt
@@ -1,0 +1,18 @@
+Hardware:
+
+    Hardware Overview:
+
+      Model Name: MacBook Pro
+      Model Identifier: MacBookPro10,1
+      Processor Name: Intel Core i7
+      Processor Speed: 2.7 GHz
+      Number of Processors: 1
+      Total Number of Cores: 4
+      L2 Cache (per Core): 256 KB
+      L3 Cache: 6 MB
+      Memory: 16 GB
+      Boot ROM Version: MBP101.00EE.B18
+      SMC Version (system): 2.3f36
+      Serial Number (system): C02L92KLFFT1
+      Hardware UUID: 33977478-9D0C-5EEB-81FF-329B2812B00F
+

--- a/lib/tests/fixtures/output/system_profiler/virtualbox.txt
+++ b/lib/tests/fixtures/output/system_profiler/virtualbox.txt
@@ -1,0 +1,16 @@
+Hardware:
+
+    Hardware Overview:
+
+      Model Name: MacBook Pro
+      Model Identifier: MacBookPro11,3
+      Processor Speed: 2.69 GHz
+      Number of Processors: 1
+      Total Number of Cores: 2
+      L2 Cache (per Processor): 256 KB
+      L3 Cache (per Processor): 12 MB
+      Memory: 2 GB
+      Boot ROM Version: VirtualBox
+      SMC Version (system): 2.3f35
+      Serial Number (system): 0
+      Hardware UUID: B64A21B6-2753-419E-A3BD-A5F28E0ACDF0

--- a/lib/tests/fixtures/output/system_profiler/vmware.txt
+++ b/lib/tests/fixtures/output/system_profiler/vmware.txt
@@ -1,0 +1,17 @@
+Hardware:
+
+    Hardware Overview:
+
+      Model Name: Mac
+      Model Identifier: VMware7,1
+      Processor Speed: 2.19 GHz
+      Number of Processors: 2
+      Total Number of Cores: 2
+      L2 Cache (per Processor): 256 KB
+      L3 Cache (per Processor): 6 MB
+      Memory: 2 GB
+      Boot ROM Version: VMW71.00V.0.B64.1307300729
+      SMC Version (system): 1.16f8
+      Serial Number (system): VMWQiKnt+gSYlGGr+6MVPk0vw
+      Hardware UUID: 00000000-0000-1000-8000-0050569BDE3D
+

--- a/lib/tests/fixtures/system_profiler_fixtures.hpp
+++ b/lib/tests/fixtures/system_profiler_fixtures.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "../fixtures.hpp"
+#include <internal/sources/system_profiler_source.hpp>
+#include <leatherman/file_util/file.hpp>
+
+namespace lth_file = leatherman::file_util;
+
+namespace whereami { namespace testing { namespace system_profiler {
+
+    class system_profiler_fixture : public sources::system_profiler
+    {
+    public:
+        /**
+         * Common fixture paths within the fixture base path
+         */
+        constexpr static char const* SYSTEM_PROFILER_PHYSICAL {"output/system_profiler/physical.txt"};
+        constexpr static char const* SYSTEM_PROFILER_VMWARE {"output/system_profiler/vmware.txt"};
+
+        /**
+         * Constructor specifying a path to the system_profiler output fixture
+         */
+        explicit system_profiler_fixture(std::string const& fixture_path)
+            : system_profiler_fixture_path_(fixture_path) { };
+
+    protected:
+        /**
+         * The path to the desired system_profiler output
+         */
+        std::string system_profiler_fixture_path_;
+
+        /**
+         * Read system_profiler output from a fixture instead of stdout
+         */
+        virtual std::string read_system_profiler_output(const std::vector<std::string>& args) override {
+            return lth_file::read(fixture_full_path(system_profiler_fixture_path_));
+        }
+    };
+
+}}}  // namespace whereami::testing::system_profiler

--- a/lib/tests/fixtures/system_profiler_fixtures.hpp
+++ b/lib/tests/fixtures/system_profiler_fixtures.hpp
@@ -15,6 +15,7 @@ namespace whereami { namespace testing { namespace system_profiler {
          * Common fixture paths within the fixture base path
          */
         constexpr static char const* SYSTEM_PROFILER_PHYSICAL {"output/system_profiler/physical.txt"};
+        constexpr static char const* SYSTEM_PROFILER_VIRTUALBOX {"output/system_profiler/virtualbox.txt"};
         constexpr static char const* SYSTEM_PROFILER_VMWARE {"output/system_profiler/vmware.txt"};
 
         /**

--- a/lib/tests/sources/system_profiler_source.cc
+++ b/lib/tests/sources/system_profiler_source.cc
@@ -1,0 +1,29 @@
+#include <catch.hpp>
+#include <iostream>
+#include <internal/sources/system_profiler_source.hpp>
+#include "../fixtures/system_profiler_fixtures.hpp"
+
+using namespace std;
+using namespace whereami::sources;
+using namespace whereami::testing;
+using namespace whereami::testing::system_profiler;
+
+SCENARIO("Using the system profiler data source") {
+    WHEN("system_profiler is available") {
+        system_profiler_fixture system_profiler_source(system_profiler_fixture::SYSTEM_PROFILER_PHYSICAL);
+        THEN("the values are successfully collected") {
+            REQUIRE(system_profiler_source.boot_rom_version() == "MBP101.00EE.B18");
+            REQUIRE(system_profiler_source.model_identifier() == "MacBookPro10,1");
+            REQUIRE(system_profiler_source.system_serial_number() == "C02L92KLFFT1");
+        }
+    }
+
+    WHEN("system_profiler is not available") {
+        system_profiler_fixture system_profiler_source({});
+        THEN("no information is collected") {
+            REQUIRE(system_profiler_source.boot_rom_version() == "");
+            REQUIRE(system_profiler_source.model_identifier() == "");
+            REQUIRE(system_profiler_source.system_serial_number() == "");
+        }
+    }
+}


### PR DESCRIPTION
Adds a new data source for the `system_profiler` tool on MacOS, and uses it to improve detection of VirtualBox and VMware environments. No new metadata has been added.