### PR TITLE
(maint) Fix builds on MacOS with static boost, shared leatherman

### DIFF
--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -28,6 +28,10 @@ target_link_libraries(lib${PROJECT_NAME}_test
     ${LEATHERMAN_LIBRARIES}
 )
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND BOOST_STATIC AND LEATHERMAN_USE_LOCALES)
+    target_link_libraries(lib${PROJECT_NAME}_test iconv)
+endif()
+
 add_test(NAME "unit_tests" COMMAND lib${PROJECT_NAME}_test)
 
 # Generate a file containing the path to the fixtures

--- a/locales/whereami.pot
+++ b/locales/whereami.pot
@@ -18,8 +18,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. debug
+#: lib/src/detectors/openvz_detector.cc
 #: lib/src/sources/dmi_source.cc
-msgid " cannot be accessed."
+msgid "{1}: file could not be read."
+msgstr ""
+
+#. debug
+#: lib/src/sources/cgroup_source.cc
+msgid "File {!} could not be read"
+msgstr ""
+
+#. debug
+#: lib/src/sources/dmi_source.cc
+msgid " not found."
 msgstr ""
 
 #. debug
@@ -34,12 +45,12 @@ msgstr ""
 
 #. debug
 #: lib/src/sources/dmi_source.cc
-msgid "{1}: {2}."
+msgid "Error while running dmidecode ({1})"
 msgstr ""
 
 #. debug
 #: lib/src/sources/dmi_source.cc
-msgid "{1}: file could not be read."
+msgid "{1}: {2}."
 msgstr ""
 
 #. debug


### PR DESCRIPTION
Fix pulled from
https://github.com/puppetlabs/facter/blob/3.8.0/lib/tests/CMakeLists.txt#L160-L162