### PR TITLE
(maint) Fix cpuid on macOS 10.11+

### DIFF
--- a/lib/src/sources/cpuid_source.cc
+++ b/lib/src/sources/cpuid_source.cc
@@ -7,7 +7,12 @@ namespace whereami { namespace sources {
 
     cpuid_registers cpuid_base::read_cpuid(unsigned int leaf, unsigned int subleaf) const {
         cpuid_registers result;
-#if defined(__x86_64__) || defined(__i386__)
+#ifdef __APPLE__
+        asm volatile(
+            "xchgq %%rbx, %q1; cpuid; xchgq %%rbx, %q1"
+            : "=a" (result.eax), "=&r" (result.ebx), "=c" (result.ecx), "=d" (result.edx)
+            : "a" (leaf), "c" (subleaf));
+#elif defined(__x86_64__) || defined(__i386__)
         // ebx is the PIC register in 32-bit environments; Don't clobber it
         asm volatile(
             "xchgl %%ebx,%k1; xor %%ebx,%%ebx; cpuid; xchgl %%ebx,%k1"


### PR DESCRIPTION
On macOS 10.11+, cpuid causes a crash in Facter. Fixed by using the example code
to query cpuid at
https://github.com/jedisct1/libsodium/blob/1.0.13/src/libsodium/sodium/runtime.c#L86-L101
instead.