### PR TITLE
(maint) Only preserve ebx when it's absolutely necessary

### DIFF
--- a/lib/src/sources/cpuid_source.cc
+++ b/lib/src/sources/cpuid_source.cc
@@ -14,7 +14,7 @@ namespace whereami { namespace sources {
         // see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47602
         // We may not need this at all on modern GCCs, but ¯\_(ツ)_/¯
         asm volatile(
-            "mov %%ebx,%k1; xor %%ebx,%%ebx; cpuid; xchgl %%ebx,%k1"
+            "mov %%ebx,%k1; cpuid; xchgl %%ebx,%k1"
             : "=a" (result.eax), "=&r" (result.ebx), "=c" (result.ecx), "=d" (result.edx)
             : "a" (leaf), "c" (subleaf));
 #elif defined(__i386__) || defined(__x86_64__)


### PR DESCRIPTION
Preserving ebx is only needed on i386 when building position-
independent code, since it is permanently reserved for PIC
purposes, and is invisible to the compiler's register allocator.

On x86_64 and on non-PIC x86, we can rely on the compiler to
properly handle our clobbering of that register. This is a
compiler bug in my view, but that doesn't stop us from having
to deal with it.