### PR TITLE
(FACT-1747) Fix segfault in dmidecode data source

### DIFF
--- a/lib/inc/internal/sources/dmi_source.hpp
+++ b/lib/inc/internal/sources/dmi_source.hpp
@@ -21,10 +21,11 @@ namespace whereami { namespace sources {
          */
         virtual bool collect_data_from_sys();
         /**
-         * Attempt to collect data from dmidecode executable (requires root)
+         * Attempt to collect data from dmidecode executable output (requires root)
+         * @param output The output of the dmidecode executable
          * @return Whether data was collected
          */
-        virtual bool collect_data_from_dmidecode();
+        virtual bool collect_data_from_dmidecode(std::string const& output);
         /**
          * Examine a line of dmidecode output for useful information
          * @param line The contents of the line

--- a/lib/tests/fixtures/dmi_fixtures.cc
+++ b/lib/tests/fixtures/dmi_fixtures.cc
@@ -11,22 +11,21 @@ namespace whereami { namespace testing { namespace dmi {
         return fixture_root + sys_fixture_path_ + filename;
     }
 
-    bool dmi_fixture::collect_data_from_dmidecode()
+    smbios_data const* dmi_fixture::data()
     {
-        std::string dmidecode_output;
+        if (!data_) {
+            string dmidecode_output;
+            load_fixture(dmidecode_fixture_path_, dmidecode_output);
 
-        if (!load_fixture(dmidecode_fixture_path_, dmidecode_output)) {
-            return false;
+            collect_data_from_dmidecode(dmidecode_output);
+
+            if (data_ == nullptr) {
+                if (!collect_data_from_sys()) {
+                    data_.reset(new smbios_data);
+                }
+            }
         }
-
-        int dmi_type {-1};
-
-        leatherman::util::each_line(dmidecode_output, [&](string& line) {
-            parse_dmidecode_line(line, dmi_type);
-            return true;
-        });
-
-        return data_.get() != nullptr;
+        return data_.get();
     }
 
     dmi_fixture_values::dmi_fixture_values(sources::smbios_data&& data)

--- a/lib/tests/fixtures/dmi_fixtures.hpp
+++ b/lib/tests/fixtures/dmi_fixtures.hpp
@@ -38,10 +38,10 @@ namespace whereami { namespace testing { namespace dmi {
          */
         std::string sys_path(std::string const& filename = "") const override;
         /**
-         * Read dmidecode output data from a fixture file
-         * @return
+         * Collect data from dmidecode and/or /sys/
+         * @return A pointer to the data object
          */
-        bool collect_data_from_dmidecode() override;
+        sources::smbios_data const* data() override;
         /**
          * The dmidecode fixture file path
          */


### PR DESCRIPTION
Corrects a simple logical error in the dmidecode data source that
allowed an empty data object to be considered non-empty.