### PR TITLE
(FACT-1661) Add Solaris LDom detector

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PROJECT_SOURCES
     "src/detectors/docker_detector.cc"
     "src/detectors/hyperv_detector.cc"
     "src/detectors/kvm_detector.cc"
+    "src/detectors/ldom_detector.cc"
     "src/detectors/lpar_detector.cc"
     "src/detectors/lxc_detector.cc"
     "src/detectors/nspawn_detector.cc"

--- a/lib/inc/internal/detectors/ldom_detector.hpp
+++ b/lib/inc/internal/detectors/ldom_detector.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <whereami/result.hpp>
+
+namespace whereami { namespace detectors {
+
+    /**
+     * Solaris ldom detector function
+     * @return the ldom result
+     */
+    result ldom();
+
+    /**
+     * Collect metadata from the output of virtinfo -a -p
+     * @param res An ldom result object
+     * @param virtinfo_output The output of `virtinfo -a -p`
+     */
+    void parse_virtinfo_output(result& res, std::string const& virtinfo_output);
+
+}}  // namespace whereami::detectors

--- a/lib/src/detectors/ldom_detector.cc
+++ b/lib/src/detectors/ldom_detector.cc
@@ -1,0 +1,108 @@
+#include <internal/detectors/ldom_detector.hpp>
+#include <leatherman/execution/execution.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <leatherman/util/regex.hpp>
+#include <leatherman/util/strings.hpp>
+#include <boost/algorithm/string.hpp>
+#include <internal/vm.hpp>
+
+using namespace std;
+using namespace leatherman::util;
+namespace lth_exe = leatherman::execution;
+
+namespace whereami { namespace detectors {
+
+    void parse_virtinfo_output(result& res, string const& virtinfo_output)
+    {
+        /*
+          // Example `virtinfo -a -p` output:
+          VERSION 1.0
+          DOMAINROLE|impl=LDoms|control=true|io=true|service=true|root=true
+          DOMAINNAME|name=primary
+          DOMAINUUID|uuid=8e0d6ec5-cd55-e57f-ae9f-b4cc050999a4
+          DOMAINCONTROL|name=san-t2k-6
+          DOMAINCHASSIS|serialno=0704RB0280
+        */
+
+        each_line(virtinfo_output, [&] (string& line) {
+            if (!re_search(line, boost::regex("^DOMAIN"))) {
+                return true;
+            }
+
+            vector<string> items;
+            boost::split(items, line, boost::is_any_of("|"));
+
+            if (items.empty()) {
+                return true;
+            }
+
+            if (items[0] == "DOMAINROLE") {
+                // e.g items = ["DOMAINROLE", "impl=LDoms", "control=false", ... ]
+                unordered_map<string, string> role_data;
+                for (auto const& item : items) {
+                    auto pos = item.find('=');
+                    if (pos != string::npos) {
+                        role_data[item.substr(0, pos)] = item.substr(pos + 1);
+                    }
+                }
+
+                if (role_data["impl"] == "LDoms") {
+                    res.validate();
+                } else {
+                    return false;
+                }
+
+                res.set("role_control", (role_data["control"] == "true"));
+                res.set("role_io",      (role_data["io"] == "true"));
+                res.set("role_service", (role_data["service"] == "true"));
+                res.set("role_root",    (role_data["root"] == "true"));
+                return true;
+            }
+
+            if (items.size() == 2) {
+                // e.g. items = ["DOMAINNAME", "name=sol10-2"]
+                auto pos = items[1].find('=');
+                if (pos == string::npos) {
+                    return true;
+                }
+                string value = items[1].substr(pos + 1);
+
+                if (items[0] == "DOMAINNAME") {
+                    res.set("domain_name", move(value));
+                } else if (items[0] == "DOMAINUUID") {
+                    res.set("domain_uuid", move(value));
+                } else if (items[0] == "DOMAINCONTROL") {
+                    res.set("control_domain", move(value));
+                } else if (items[0] == "DOMAINCHASSIS") {
+                    res.set("chassis_serial", move(value));
+                }
+            }
+
+            return true;
+        });
+    }
+
+    result ldom()
+    {
+        result res {vm::ldom};
+
+        string virtinfo_path = lth_exe::which("virtinfo");
+
+        if (virtinfo_path.empty()) {
+            LOG_DEBUG("virtinfo executable not found");
+            return res;
+        }
+
+        auto virtinfo_result = lth_exe::execute(virtinfo_path, vector<string> {"-a", "-p"});
+
+        if (!virtinfo_result.success) {
+            LOG_DEBUG("Error while running virtinfo -a -p ({1})");
+            return res;
+        }
+
+        parse_virtinfo_output(res, virtinfo_result.output);
+
+        return res;
+    }
+
+}}  // namespace whereami::detectors

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -7,6 +7,7 @@
 #include <internal/detectors/docker_detector.hpp>
 #include <internal/detectors/hyperv_detector.hpp>
 #include <internal/detectors/kvm_detector.hpp>
+#include <internal/detectors/ldom_detector.hpp>
 #include <internal/detectors/lpar_detector.hpp>
 #include <internal/detectors/lxc_detector.hpp>
 #include <internal/detectors/openvz_detector.hpp>
@@ -109,6 +110,14 @@ namespace whereami {
         if (zone_result.valid()) {
             results.emplace_back(zone_result);
         }
+
+#if defined(__sparc__)
+        auto ldom_result = detectors::ldom();
+
+        if (ldom_result.valid()) {
+            results.emplace_back(ldom_result);
+        }
+#endif
 
         return results;
     }

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_CASES
     "detectors/docker_detector.cc"
     "detectors/hyperv_detector.cc"
     "detectors/kvm_detector.cc"
+    "detectors/ldom_detector.cc"
     "detectors/lpar_detector.cc"
     "detectors/lxc_detector.cc"
     "detectors/nspawn_detector.cc"

--- a/lib/tests/detectors/ldom_detector.cc
+++ b/lib/tests/detectors/ldom_detector.cc
@@ -1,0 +1,54 @@
+#include <catch.hpp>
+#include <internal/detectors/ldom_detector.hpp>
+#include <internal/vm.hpp>
+#include "../fixtures.hpp"
+
+using namespace whereami::detectors;
+using namespace whereami::testing;
+using namespace std;
+
+SCENARIO("Using the Solaris LDom detector") {
+    WHEN("gathering metadata from `virtinfo -a -p` inside an LDom guest") {
+        string virtinfo_output;
+        load_fixture("output/virtinfo/guest.txt", virtinfo_output);
+        whereami::result res {whereami::vm::ldom};
+        parse_virtinfo_output(res, virtinfo_output);
+
+        THEN("the result is valid") {
+            REQUIRE(res.valid());
+        }
+
+        THEN("the data is collected and set") {
+            REQUIRE_FALSE(res.get<bool>("role_control"));
+            REQUIRE_FALSE(res.get<bool>("role_io"));
+            REQUIRE_FALSE(res.get<bool>("role_service"));
+            REQUIRE_FALSE(res.get<bool>("role_root"));
+            REQUIRE(res.get<string>("domain_name") == "sol10-2");
+            REQUIRE(res.get<string>("domain_uuid") == "ddfb4bdc-29f7-4b44-8d62-d3b0eaafd966");
+            REQUIRE(res.get<string>("control_domain") == "opdx-a0-sun2");
+            REQUIRE(res.get<string>("chassis_serial") == "AK00358110");
+        }
+    }
+
+    WHEN("gathering metadata from `virtinfo -a -p` inside an LDom host") {
+        string virtinfo_output;
+        load_fixture("output/virtinfo/host.txt", virtinfo_output);
+        whereami::result res {whereami::vm::ldom};
+        parse_virtinfo_output(res, virtinfo_output);
+
+        THEN("the result is valid") {
+            REQUIRE(res.valid());
+        }
+
+        THEN("the data is collected and set") {
+            REQUIRE(res.get<bool>("role_control"));
+            REQUIRE(res.get<bool>("role_io"));
+            REQUIRE(res.get<bool>("role_service"));
+            REQUIRE(res.get<bool>("role_root"));
+            REQUIRE(res.get<string>("domain_name") == "primary");
+            REQUIRE(res.get<string>("domain_uuid") == "b7e5fa70-bc64-458f-a4b4-c8dc9213fa3b");
+            REQUIRE(res.get<string>("control_domain") == "opdx-a0-sun-01");
+            REQUIRE(res.get<string>("chassis_serial") == "AK00214288");
+        }
+    }
+}

--- a/lib/tests/fixtures/output/virtinfo/guest.txt
+++ b/lib/tests/fixtures/output/virtinfo/guest.txt
@@ -1,0 +1,6 @@
+VERSION 1.0
+DOMAINROLE|impl=LDoms|control=false|io=false|service=false|root=false
+DOMAINNAME|name=sol10-2
+DOMAINUUID|uuid=ddfb4bdc-29f7-4b44-8d62-d3b0eaafd966
+DOMAINCONTROL|name=opdx-a0-sun2
+DOMAINCHASSIS|serialno=AK00358110

--- a/lib/tests/fixtures/output/virtinfo/host.txt
+++ b/lib/tests/fixtures/output/virtinfo/host.txt
@@ -1,0 +1,6 @@
+VERSION 1.0
+DOMAINROLE|impl=LDoms|control=true|io=true|service=true|root=true
+DOMAINNAME|name=primary
+DOMAINUUID|uuid=b7e5fa70-bc64-458f-a4b4-c8dc9213fa3b
+DOMAINCONTROL|name=opdx-a0-sun-01
+DOMAINCHASSIS|serialno=AK00214288


### PR DESCRIPTION
Adds a detector function for Solaris LDoms that is called on sparc
platforms only. Relies on the `virtinfo` executable (like facter).
Example output:
```
  ldom => {
    chassis_serial => "AK00358110",
    control_domain => "opdx-a0-sun2",
    domain_name => "sol11-2",
    domain_uuid => "f6c6e7ba-9092-42b2-9604-8ff289bb712a",
    role_control => false,
    role_io => false,
    role_root => false,
    role_service => false
  }
```
This will need another PR to puppet-agent once merged so that the agent will actually build whereami on Solaris - it worked in a test build I did today.