### PR TITLE
(FACT-1749) Fix error when WMI reports no data

### DIFF
--- a/lib/tests/whereami.cc
+++ b/lib/tests/whereami.cc
@@ -5,3 +5,7 @@
 SCENARIO("version() returns the version") {
     REQUIRE(whereami::version() == WHEREAMI_VERSION_WITH_COMMIT);
 }
+
+SCENARIO("Checking for hypervisors doesn't throw") {
+    REQUIRE_NOTHROW(whereami::hypervisors());
+}


### PR DESCRIPTION
Checks that WMI query object results are not empty before attempting to
get values out of them.