### PR TITLE
(maint) Include missing Xen and nspawn detectors

### DIFF
--- a/lib/inc/internal/detectors/xen_detector.hpp
+++ b/lib/inc/internal/detectors/xen_detector.hpp
@@ -18,7 +18,7 @@ namespace whereami { namespace detectors {
      * Path to the directory holding Xen's capabilities file.
      * /proc/xen/capabilities contains the string "control_d" on dom0, and is absent on domU.
      */
-    static const std::string xen_path {"proc/xen"};
+    static const std::string xen_path {"/proc/xen"};
 
     /**
      * Determine whether the current domain has a /proc/xen directory. This should be present on both PV and HVM.

--- a/lib/inc/internal/vm.hpp
+++ b/lib/inc/internal/vm.hpp
@@ -6,128 +6,58 @@
 namespace whereami { namespace vm {
 
     /**
-     * The name for VMWare virtual machine.
+     * The name for VMWare virtual machines.
      */
-    constexpr static char const* vmware{"vmware"};
+    constexpr static char const* vmware {"vmware"};
 
     /**
-     * The name for VirtualBox virtual machine.
+     * The name for VirtualBox virtual machines.
      */
-    constexpr static char const* virtualbox{"virtualbox"};
+    constexpr static char const* virtualbox {"virtualbox"};
 
     /**
-     * The name for Parallels virtual machine.
+     * The name for Docker containres.
      */
-    constexpr static char const* parallels{"parallels"};
+    constexpr static char const* docker {"docker"};
 
     /**
-     * The name for VMware Server virtual machine.
+     * The name for LXC containers.
      */
-    constexpr static char const* vmware_server{"vmware_server"};
+    constexpr static char const* lxc {"lxc"};
 
     /**
-     * The name for VMware Workstation virtual machine.
+     * The name for systemd-nspawn containers.
      */
-    constexpr static char const* vmware_workstation{"vmware_workstation"};
+    constexpr static char const* systemd_nspawn {"systemd_nspawn"};
 
     /**
-     * The name for Docker virtual machine.
+     * The name for Xen virtual machines.
      */
-    constexpr static char const* docker{"docker"};
+    constexpr static char const* xen {"xen"};
 
     /**
-     * The name for LXC virtual machine.
+     * The name for OpenVZ containers.
      */
-    constexpr static char const* lxc{"lxc"};
+    constexpr static char const* openvz {"openvz"};
 
     /**
-     * The name for systemd-nspawn
+     * The name for KVM (QEMU) virtual machines.
      */
-    constexpr static char const* systemd_nspawn{"systemd_nspawn"};
+    constexpr static char const* kvm {"kvm"};
 
     /**
-     * The name for Google Compute Engine virtual machine.
+     * The name for Microsoft Hyper-V virtual machines.
      */
-    constexpr static char const* gce{"gce"};
-
-    /**
-     * The name for OpenStack-hosted virtual machine, when OpenStack defines the machine type.
-     */
-    constexpr static char const* openstack{"openstack"};
-
-    /**
-     * The name for Xen privileged domain virtual machine.
-     */
-    constexpr static char const* xen_privileged{"xen0"};
-
-    /**
-     * The name for Xen unprivileged domain virtual machine.
-     */
-    constexpr static char const* xen_unprivileged{"xenu"};
-
-    /**
-     * The name for Xen Hardware virtual machine.
-     */
-    constexpr static char const* xen_hardware{"xenhvm"};
-
-    /**
-     * The name for Xen virtual machine (on Windows)
-     */
-    constexpr static char const* xen{"xen"};
-
-    /**
-     * The name for IBM System Z virtual machine.
-     */
-    constexpr static char const* zlinux{"zlinux"};
-
-    /**
-     * The name for Linux-VServer host virtual machine.
-     */
-    constexpr static char const* vserver_host{"vserver_host"};
-
-    /**
-     * The name for Linux-VServer virtual machine.
-     */
-    constexpr static char const* vserver{"vserver"};
-
-    /**
-     * The name for OpenVZ virtual machines.
-     */
-    constexpr static char const* openvz{"openvz"};
-
-    /**
-     * The name for KVM (QEMU) virtual machine.
-     */
-    constexpr static char const* kvm{"kvm"};
-
-    /**
-     * The name for Bochs virtual machine.
-     */
-    constexpr static char const* bochs{"bochs"};
-
-    /**
-     * The name for Microsoft Hyper-V virtual machine.
-     */
-    constexpr static char const* hyperv{"hyperv"};
-
-    /**
-     * The name for Red Hat Enterprise Virtualization virtual machine.
-     */
-    constexpr static char const* redhat_ev{"rhev"};
-
-    /**
-     * The name for oVirt virtual machine.
-     */
-    constexpr static char const* ovirt{"ovirt"};
+    constexpr static char const* hyperv {"hyperv"};
 
     /**
      * The name for Solaris zones
      */
-    constexpr static char const* zone{"zone"};
+    constexpr static char const* zone {"zone"};
 
     /**
-     * The name for Solaris ldom
+     * The name for Solaris LDoms
      */
-    constexpr static char const* ldom{"ldom"};
+    constexpr static char const* ldom {"ldom"};
 
 }}  // namespace whereami::vm

--- a/lib/src/detectors/xen_detector.cc
+++ b/lib/src/detectors/xen_detector.cc
@@ -1,3 +1,4 @@
+#include <internal/vm.hpp>
 #include <internal/detectors/xen_detector.hpp>
 #include <leatherman/file_util/file.hpp>
 #include <leatherman/logging/logging.hpp>
@@ -36,14 +37,17 @@ namespace whereami { namespace detectors {
     }
 
     result xen(const cpuid& cpuid_source) {
-        result res{"xen"};
+        result res {vm::xen};
 
-        if (!has_xen_path()) {
+        // The Xen CPUID vendor string will only show up on HVM
+        auto is_hvm = cpuid_source.has_vendor("XenVMMXenVMM");
+
+        if (!is_hvm && !has_xen_path()) {
             return res;
         }
 
         res.validate();
-        res.set("context", cpuid_source.has_vendor("XenVMMXenVMM") ? "hvm" : "pv");
+        res.set("context", is_hvm ? "hvm" : "pv");
 
         // Determine whether this is dom0 or domU
         res.set("privileged", is_xen_privileged());

--- a/lib/src/whereami.cc
+++ b/lib/src/whereami.cc
@@ -3,20 +3,22 @@
 #include <internal/vm.hpp>
 #include <internal/sources/cgroup_source.hpp>
 #include <internal/sources/cpuid_source.hpp>
+#include <internal/sources/system_profiler_source.hpp>
 #include <internal/detectors/docker_detector.hpp>
 #include <internal/detectors/hyperv_detector.hpp>
 #include <internal/detectors/kvm_detector.hpp>
 #include <internal/detectors/lxc_detector.hpp>
+#include <internal/detectors/nspawn_detector.hpp>
 #include <internal/detectors/openvz_detector.hpp>
 #include <internal/detectors/virtualbox_detector.hpp>
 #include <internal/detectors/vmware_detector.hpp>
+#include <internal/detectors/xen_detector.hpp>
 #include <leatherman/logging/logging.hpp>
 
 #if defined(_WIN32)
 #include <internal/sources/wmi_source.hpp>
 #else
 #include <internal/sources/dmi_source.hpp>
-#include <internal/sources/system_profiler_source.hpp>
 #endif
 
 using namespace std;
@@ -69,6 +71,12 @@ namespace whereami {
             results.emplace_back(lxc_result);
         }
 
+        auto nspawn_result = detectors::nspawn(cgroup_source);
+
+        if (nspawn_result.valid()) {
+            results.emplace_back(nspawn_result);
+        }
+
         auto openvz_result = detectors::openvz();
 
         if (openvz_result.valid()) {
@@ -85,6 +93,12 @@ namespace whereami {
 
         if (hyperv_result.valid()) {
             results.emplace_back(hyperv_result);
+        }
+
+        auto xen_result = detectors::xen(cpuid_source);
+
+        if (xen_result.valid()) {
+            results.emplace_back(xen_result);
         }
 
         return results;


### PR DESCRIPTION
Calls to the Xen and systemd-nspawn detectors were missing from the hypervisors() detection function.

I also noticed some pretty glaring errors in the Xen detector itself and corrected them - I think this is probably the result of rushing to refactor and merge it in order to get libwhereami into the 5.2.x build :(.

I built an agent with this branch on a few OSes (Windows 2012 and i386 and x86_64 Ubuntus) and no new build problems seem to have arisen.