### PR TITLE
(FACT-1784) Correctly initialize lparstat data source

### DIFF
--- a/lib/inc/internal/sources/lparstat_source.hpp
+++ b/lib/inc/internal/sources/lparstat_source.hpp
@@ -12,6 +12,11 @@ namespace whereami { namespace sources {
     struct lparstat_data
     {
         /**
+         * Default empty constructor
+         */
+        lparstat_data(): partition_name(""), partition_number(0), wpar_key(0), wpar_configured_id(0) { }
+
+        /**
          * The partition name
          */
         std::string partition_name;

--- a/lib/src/sources/lparstat_source.cc
+++ b/lib/src/sources/lparstat_source.cc
@@ -66,7 +66,7 @@ namespace whereami { namespace sources {
 
         parse_oslevel_output(oslevel_result.output);
 
-        return true;
+        return version_.first > 0;
     }
 
     void lparstat::parse_oslevel_output(std::string const& oslevel_output)
@@ -156,4 +156,4 @@ namespace whereami { namespace sources {
         });
     }
 
-}}
+}}  // whereami::sources

--- a/lib/tests/detectors/lpar_detector.cc
+++ b/lib/tests/detectors/lpar_detector.cc
@@ -9,15 +9,40 @@ using namespace whereami::testing::lparstat;
 using namespace std;
 
 SCENARIO("Using the LPAR detector") {
-    WHEN("Running inside a LPAR") {
-        lparstat_fixture lparstat_source {"5.3.0.0", "output/lparstat/lpar.txt"};
-        auto res = lpar(lparstat_source);
-        THEN("the result is valid") {
-            REQUIRE(res.valid());
+    WHEN("Running on AIX") {
+        WHEN("Running inside an LPAR") {
+            lparstat_fixture lparstat_source {"5.3.0.0", "output/lparstat/lpar.txt"};
+            auto res = lpar(lparstat_source);
+            THEN("The result is valid") {
+                REQUIRE(res.valid());
+            }
+            THEN("The result has the expected metadata") {
+                REQUIRE(res.get<string>("partition_name") == "aix-71-agent3");
+                REQUIRE(res.get<int>("partition_number") == 16);
+            }
         }
-        THEN("the result has the expected metadata") {
-            REQUIRE(res.get<string>("partition_name") == "aix-71-agent3");
-            REQUIRE(res.get<int>("partition_number") == 16);
+        WHEN("`oslevel` suggests AIX but lparstat output is unusable for some reason") {
+            lparstat_fixture lparstat_source {"7.1.0.0", "output/lparstat/kvm_power8.txt"};
+            auto res = lpar(lparstat_source);
+            THEN("The result is not valid") {
+                REQUIRE_FALSE(res.valid());
+            }
+            THEN("The data is still correctly initialized") {
+                REQUIRE(res.get<string>("partition_name").empty());
+                REQUIRE(res.get<int>("partition_number") == 0);
+            }
+        }
+    }
+
+    WHEN("Running outside of AIX") {
+        lparstat_fixture lparstat_source {"oslevel: command not found", "output/lparstat/kvm_power8.txt"};
+        auto res = lpar(lparstat_source);
+        THEN("The result is not valid") {
+            REQUIRE_FALSE(res.valid());
+        }
+        THEN("The data is still correctly initialized") {
+            REQUIRE(res.get<string>("partition_name").empty());
+            REQUIRE(res.get<int>("partition_number") == 0);
         }
     }
 }

--- a/lib/tests/detectors/wpar_detector.cc
+++ b/lib/tests/detectors/wpar_detector.cc
@@ -9,15 +9,40 @@ using namespace whereami::testing::lparstat;
 using namespace std;
 
 SCENARIO("Using the WPAR detector") {
-    WHEN("Running inside a WPAR") {
-        lparstat_fixture lparstat_source {"7.1.0.0", "output/lparstat/wpar.txt"};
-        auto res = wpar(lparstat_source);
-        THEN("the result is valid") {
-            REQUIRE(res.valid());
+    WHEN("Running on AIX") {
+        WHEN("Running inside a WPAR") {
+            lparstat_fixture lparstat_source {"7.1.0.0", "output/lparstat/wpar.txt"};
+            auto res = wpar(lparstat_source);
+            THEN("the result is valid") {
+                REQUIRE(res.valid());
+            }
+            THEN("the result has the expected metadata") {
+                REQUIRE(res.get<int>("key") == 1);
+                REQUIRE(res.get<int>("configured_id") == 1);
+            }
         }
-        THEN("the result has the expected metadata") {
-            REQUIRE(res.get<int>("key") == 1);
-            REQUIRE(res.get<int>("configured_id") == 1);
+        WHEN("Not running inside a WPAR") {
+            lparstat_fixture lparstat_source {"7.1.0.0", "output/lparstat/lpar.txt"};
+            auto res = wpar(lparstat_source);
+            THEN("The result is not valid") {
+                REQUIRE_FALSE(res.valid());
+            }
+            THEN("The data is still correctly initialized") {
+                REQUIRE(res.get<int>("key") == 0);
+                REQUIRE(res.get<int>("configured_id") == 0);
+            }
+        }
+    }
+
+    WHEN("Running outside of AIX") {
+        lparstat_fixture lparstat_source {"oslevel: command not found", "output/lparstat/kvm_power8.txt"};
+        auto res = wpar(lparstat_source);
+        THEN("The result is not valid") {
+            REQUIRE_FALSE(res.valid());
+        }
+        THEN("The data is still correctly initialized") {
+            REQUIRE(res.get<int>("key") == 0);
+            REQUIRE(res.get<int>("configured_id") == 0);
         }
     }
 }

--- a/lib/tests/fixtures/lparstat_fixtures.hpp
+++ b/lib/tests/fixtures/lparstat_fixtures.hpp
@@ -23,7 +23,7 @@ namespace whereami { namespace testing { namespace lparstat {
          */
         bool collect_aix_version_from_oslevel() override {
             parse_oslevel_output(version_string_);
-            return true;
+            return this->version_.first > 0;
         }
 
         /**

--- a/lib/tests/fixtures/output/lparstat/kvm_power8.txt
+++ b/lib/tests/fixtures/output/lparstat/kvm_power8.txt
@@ -1,0 +1,1 @@
+lparstat: is not supported on the Power KVM pSeries Guest platform

--- a/lib/tests/sources/lparstat_source.cc
+++ b/lib/tests/sources/lparstat_source.cc
@@ -7,20 +7,39 @@ using namespace whereami::sources;
 using namespace whereami::testing::lparstat;
 
 SCENARIO("Using the lparstat data source") {
+    WHEN("Running on AIX") {
+        WHEN("LPAR information is available") {
+            WHEN("WPAR information is available") {
+                THEN("LPAR and WPAR fields are filled") {
+                    lparstat_fixture lparstat_source {"7.1.0.0", "output/lparstat/wpar.txt"};
+                    REQUIRE(lparstat_source.partition_number() == 16);
+                    REQUIRE(lparstat_source.partition_name() == "aix-71-agent3");
+                    REQUIRE(lparstat_source.wpar_key() == 1);
+                    REQUIRE(lparstat_source.wpar_configured_id() == 1);
+                }
+            }
 
-    WHEN("WPAR information is not available") {
-        lparstat_fixture lparstat_source {"5.3.0.0", "output/lparstat/lpar.txt"};
-        REQUIRE(lparstat_source.partition_number() == 16);
-        REQUIRE(lparstat_source.partition_name() == "aix-71-agent3");
-        REQUIRE(lparstat_source.wpar_key() == 0);
-        REQUIRE(lparstat_source.wpar_configured_id() == 0);
+            WHEN("WPAR INFORMATION is not available") {
+                THEN("LPAR fields are filled and WPAR fields are empty") {
+                    lparstat_fixture lparstat_source {"5.3.0.0", "output/lparstat/lpar.txt"};
+                    REQUIRE(lparstat_source.partition_number() == 16);
+                    REQUIRE(lparstat_source.partition_name() == "aix-71-agent3");
+                    REQUIRE(lparstat_source.wpar_key() == 0);
+                    REQUIRE(lparstat_source.wpar_configured_id() == 0);
+                }
+            }
+        }
     }
 
-    WHEN("WPAR information is available") {
-        lparstat_fixture lparstat_source {"7.1.0.0", "output/lparstat/wpar.txt"};
-        REQUIRE(lparstat_source.partition_number() == 16);
-        REQUIRE(lparstat_source.partition_name() == "aix-71-agent3");
-        REQUIRE(lparstat_source.wpar_key() == 1);
-        REQUIRE(lparstat_source.wpar_configured_id() == 1);
+    WHEN("Running outside of AIX") {
+        WHEN("An lparstat executable is available but this is not an AIX machine") {
+            THEN("the source does not attempt to collect any data and empty values are correctly initialized") {
+                lparstat_fixture lparstat_source {"0.0", "output/lparstat/kvm_power8.txt"};
+                REQUIRE(lparstat_source.partition_number() == 0);
+                REQUIRE(lparstat_source.partition_name().empty());
+                REQUIRE(lparstat_source.wpar_key() == 0);
+                REQUIRE(lparstat_source.wpar_configured_id() == 0);
+            }
+        }
     }
 }

--- a/locales/whereami.pot
+++ b/locales/whereami.pot
@@ -24,18 +24,28 @@ msgid "{1}: file could not be read."
 msgstr ""
 
 #. debug
+#: lib/src/detectors/zone_detector.cc
+msgid "zonename executable not found"
+msgstr ""
+
+#. debug
+#: lib/src/detectors/zone_detector.cc
+msgid "Error while running zonename ({1})"
+msgstr ""
+
+#. debug
+#: lib/src/detectors/zone_detector.cc
+msgid "zoneadm executable not found"
+msgstr ""
+
+#. debug
+#: lib/src/detectors/zone_detector.cc
+msgid "Error while running `zoneadm list -p` ({1})"
+msgstr ""
+
+#. debug
 #: lib/src/sources/cgroup_source.cc
 msgid "File {!} could not be read"
-msgstr ""
-
-#. debug
-#: lib/src/sources/dmi_source.cc
-msgid " not found."
-msgstr ""
-
-#. debug
-#: lib/src/sources/dmi_source.cc
-msgid "Using dmidecode to query DMI information."
 msgstr ""
 
 #. debug
@@ -50,7 +60,27 @@ msgstr ""
 
 #. debug
 #: lib/src/sources/dmi_source.cc
+msgid " not found."
+msgstr ""
+
+#. debug
+#: lib/src/sources/dmi_source.cc
 msgid "{1}: {2}."
+msgstr ""
+
+#. debug
+#: lib/src/sources/lparstat_source.cc
+msgid "oslevel executable not found"
+msgstr ""
+
+#. debug
+#: lib/src/sources/lparstat_source.cc
+msgid "lparstat executable not found"
+msgstr ""
+
+#. debug
+#: lib/src/sources/lparstat_source.cc
+msgid "Error while running lparstat ({1})"
 msgstr ""
 
 #. debug


### PR DESCRIPTION
Outside of AIX, the data in the lparstat source was left uninitialized;
This caused false positives for LPAR/WPAR on power8 machines.