### PR TITLE
(PUP-8065) Fix malformed debug print in cgroup source

### DIFF
--- a/lib/src/sources/cgroup_source.cc
+++ b/lib/src/sources/cgroup_source.cc
@@ -25,7 +25,7 @@ namespace whereami { namespace sources {
         string contents;
 
         if (!lth_file::read(file_path, contents)) {
-            LOG_DEBUG("File {!} could not be read", file_path);
+            LOG_DEBUG("File {1} could not be read", file_path);
             return;
         }
 


### PR DESCRIPTION
This typo is the actual cause of a lot of CI failures recently - it only seems to raise a `boost::too_many_args` exception on some platforms (solaris, AIX), so it went unnoticed until those platforms started being tested