### PR TITLE
(FACT-1768) Remove deprecated exception specifications

### DIFF
--- a/lib/inc/whereami/metadata.hpp
+++ b/lib/inc/whereami/metadata.hpp
@@ -51,7 +51,7 @@ namespace whereami {
          * @return
          */
         template<typename T>
-        T get(std::string const& key) const throw(boost::bad_get)
+        T get(std::string const& key) const
         {
             auto it = data_.find(key);
             if (it == data_.end()) {

--- a/lib/inc/whereami/result.hpp
+++ b/lib/inc/whereami/result.hpp
@@ -58,7 +58,7 @@ namespace whereami {
          * @return Returns the value
          */
         template<typename T>
-        T get(std::string const& key) const throw(boost::bad_get)
+        T get(std::string const& key) const
         {
             return metadata_.get<T>(key);
         }


### PR DESCRIPTION
Exception specifications are deprecated in C++11.