### PR TITLE
(maint) Remove some unused includes in tests

### DIFF
--- a/lib/tests/fixtures.cc
+++ b/lib/tests/fixtures.cc
@@ -5,12 +5,6 @@
 #include <sstream>
 #include <string>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#include <boost/thread/thread.hpp>
-#include <boost/chrono/duration.hpp>
-#pragma GCC diagnostic pop
-
 using namespace std;
 using namespace boost::filesystem;
 


### PR DESCRIPTION
These were probably just cargo-culted from other C++ projects, and boost::thread 1.67 produces an unused symbol warning under mingw, anyway